### PR TITLE
ci: Fix CRD upload to run on 'created' event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,8 @@ jobs:
   upload-crds:
     name: Upload CRDs to release
     runs-on: ubuntu-latest
-    if: github.event.action == 'published'
+    # Must run on 'created' not 'published' - releases become immutable after publishing
+    if: github.event.action == 'created'
     permissions:
       contents: write
 


### PR DESCRIPTION
The issue: GitHub releases become immutable once published, and assets cannot be uploaded to immutable releases. The error was:
"HTTP 422: Cannot upload assets to an immutable release"

The fix: Upload CRDs when the release is 'created' (draft/pre-release state), not when it's 'published' (immutable state).

Workflow sequence:
1. User creates release → 'created' event → upload-crds runs
2. User publishes release → 'published' event → build-and-publish and publish-helm-charts run

This reverts the incorrect change from commit 31c6078 which changed the trigger from 'created' to 'published'.