### PR TITLE
fix(charts): fail with clear message when ProviderConfig CRDs are missing

### DIFF
--- a/deploy/helm-charts/asya-crossplane/templates/providerconfigs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/providerconfigs.yaml
@@ -1,5 +1,36 @@
 {{- if .Values.providerConfigs.install }}
+{{- /* Fail early with actionable message if ProviderConfig CRDs are not yet registered */ -}}
+{{- $k8sCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.kubernetes.crossplane.io" -}}
+{{- if not $k8sCRD -}}
+{{- fail `
+[!] ProviderConfig CRDs are not yet available on this cluster.
+
+Crossplane providers need time to register their CRDs after installation.
+This is expected on first install — use a two-step approach:
+
+  Step 1 — install providers only (skip ProviderConfigs):
+
+    helm install asya-crossplane asya/asya-crossplane \
+      --set providerConfigs.install=false ...
+
+  Step 2 — wait for providers, then enable ProviderConfigs:
+
+    kubectl wait --for=condition=Healthy providers --all --timeout=300s
+    helm upgrade asya-crossplane asya/asya-crossplane \
+      --reuse-values --set providerConfigs.install=true
+` -}}
+{{- end }}
 {{- if .Values.providers.aws.enabled }}
+{{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.aws.upbound.io") -}}
+{{- fail `
+[!] AWS ProviderConfig CRD (providerconfigs.aws.upbound.io) is not yet available.
+
+Wait for the AWS provider to become Healthy, then re-run:
+
+    kubectl wait --for=condition=Healthy providers/provider-aws-sqs --timeout=300s
+    helm upgrade asya-crossplane asya/asya-crossplane --reuse-values --set providerConfigs.install=true
+` -}}
+{{- end }}
 ---
 apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
@@ -44,6 +75,16 @@ spec:
   {{- end }}
 {{- end }}
 {{- if .Values.providers.gcp.enabled }}
+{{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.gcp.upbound.io") -}}
+{{- fail `
+[!] GCP ProviderConfig CRD (providerconfigs.gcp.upbound.io) is not yet available.
+
+Wait for the GCP provider to become Healthy, then re-run:
+
+    kubectl wait --for=condition=Healthy providers/provider-gcp-pubsub --timeout=300s
+    helm upgrade asya-crossplane asya/asya-crossplane --reuse-values --set providerConfigs.install=true
+` -}}
+{{- end }}
 ---
 apiVersion: gcp.upbound.io/v1beta1
 kind: ProviderConfig

--- a/deploy/helm-charts/asya-crossplane/templates/providerconfigs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/providerconfigs.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.providerConfigs.install }}
-{{- /* Fail early with actionable message if ProviderConfig CRDs are not yet registered */ -}}
-{{- $k8sCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.kubernetes.crossplane.io" -}}
-{{- if not $k8sCRD -}}
+{{- /* Fail early with actionable message if ProviderConfig CRDs are not yet registered.
+       Skip checks when providerConfigs.skipCRDCheck=true (for offline helm template / GitOps). */ -}}
+{{- if not .Values.providerConfigs.skipCRDCheck }}
+{{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.kubernetes.crossplane.io") -}}
 {{- fail `
 [!] ProviderConfig CRDs are not yet available on this cluster.
 
@@ -18,9 +19,15 @@ This is expected on first install — use a two-step approach:
     kubectl wait --for=condition=Healthy providers --all --timeout=300s
     helm upgrade asya-crossplane asya/asya-crossplane \
       --reuse-values --set providerConfigs.install=true
+
+To render templates offline (helm template / GitOps), set:
+
+    --set providerConfigs.skipCRDCheck=true
 ` -}}
 {{- end }}
+{{- end }}
 {{- if .Values.providers.aws.enabled }}
+{{- if not .Values.providerConfigs.skipCRDCheck }}
 {{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.aws.upbound.io") -}}
 {{- fail `
 [!] AWS ProviderConfig CRD (providerconfigs.aws.upbound.io) is not yet available.
@@ -30,6 +37,7 @@ Wait for the AWS provider to become Healthy, then re-run:
     kubectl wait --for=condition=Healthy providers/provider-aws-sqs --timeout=300s
     helm upgrade asya-crossplane asya/asya-crossplane --reuse-values --set providerConfigs.install=true
 ` -}}
+{{- end }}
 {{- end }}
 ---
 apiVersion: aws.upbound.io/v1beta1
@@ -75,6 +83,7 @@ spec:
   {{- end }}
 {{- end }}
 {{- if .Values.providers.gcp.enabled }}
+{{- if not .Values.providerConfigs.skipCRDCheck }}
 {{- if not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providerconfigs.gcp.upbound.io") -}}
 {{- fail `
 [!] GCP ProviderConfig CRD (providerconfigs.gcp.upbound.io) is not yet available.
@@ -84,6 +93,7 @@ Wait for the GCP provider to become Healthy, then re-run:
     kubectl wait --for=condition=Healthy providers/provider-gcp-pubsub --timeout=300s
     helm upgrade asya-crossplane asya/asya-crossplane --reuse-values --set providerConfigs.install=true
 ` -}}
+{{- end }}
 {{- end }}
 ---
 apiVersion: gcp.upbound.io/v1beta1

--- a/deploy/helm-charts/asya-crossplane/templates/providers.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/providers.yaml
@@ -137,7 +137,7 @@ metadata:
   labels:
     {{- include "asya-crossplane.labels" . | nindent 4 }}
 spec:
-  package: {{ .Values.functions.flavorsRepository }}:{{ .Values.functions.flavorsVersion }}
+  package: {{ .Values.functions.flavorsRepository }}:{{ .Values.functions.flavorsVersion | default .Chart.AppVersion }}
   packagePullPolicy: {{ .Values.functions.flavorsPackagePullPolicy }}
   runtimeConfigRef:
     name: function-asya-flavors-runtime

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -1,6 +1,8 @@
-# ProviderConfig installation (set to false for first install before CRDs exist)
+# ProviderConfig installation — requires provider CRDs to be registered first.
+# On fresh installs, leave this false, wait for providers to become Healthy,
+# then upgrade with providerConfigs.install=true.
 providerConfigs:
-  install: true
+  install: false
 
 # Crossplane provider configuration
 providers:
@@ -25,7 +27,9 @@ functions:
   autoReadyVersion: "v0.6.0"
   flavorsEnabled: true
   flavorsRepository: "ghcr.io/deliveryhero/function-asya-flavors"
-  flavorsVersion: "0.5.3"
+  # flavorsVersion defaults to Chart.AppVersion (set at release time).
+  # Override only for pinning to a specific version.
+  flavorsVersion: ""
   flavorsPackagePullPolicy: IfNotPresent
   flavorsResources:
     requests:

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -3,6 +3,8 @@
 # then upgrade with providerConfigs.install=true.
 providerConfigs:
   install: false
+  # Skip CRD existence checks (for offline helm template / GitOps rendering)
+  skipCRDCheck: false
 
 # Crossplane provider configuration
 providers:

--- a/docs/setup/start-aws-eks.md
+++ b/docs/setup/start-aws-eks.md
@@ -223,15 +223,36 @@ awsProviderConfig:
     key: credentials
 ```
 
-### 3. Install Asya Crossplane Chart
+### 3. Install Asya Crossplane Chart (two-step)
+
+Crossplane providers must reach `Healthy` before their CRDs exist and ProviderConfigs
+can be created. Install with `providerConfigs.install=false` first.
 
 ```bash
 helm repo add asya https://asya.sh/charts
 helm repo update asya
 
+# Step 1: install providers, XRDs, and compositions (skip ProviderConfigs)
 helm install asya-crossplane asya/asya-crossplane --version $ASYA_VERSION \
   -n crossplane-system \
-  -f crossplane-values.yaml
+  -f crossplane-values.yaml \
+  --set providerConfigs.install=false
+```
+
+Wait for providers to register their CRDs:
+
+```bash
+kubectl wait --for=condition=Healthy providers --all --timeout=300s
+```
+
+Then enable ProviderConfigs:
+
+```bash
+# Step 2: enable ProviderConfigs (CRDs now exist)
+helm upgrade asya-crossplane asya/asya-crossplane --version $ASYA_VERSION \
+  -n crossplane-system \
+  --reuse-values \
+  --set providerConfigs.install=true
 ```
 
 ### 4. Install Gateway (Optional)


### PR DESCRIPTION
## Summary

Fixes #402 — `helm install asya-crossplane` fails with a cryptic error on blank clusters because ProviderConfig CRDs don't exist yet.

**Root cause**: The chart bundles `Provider` resources (which register CRDs) and `ProviderConfig` resources (which need those CRDs) in the same Helm release. Helm validates all manifests against the API server before applying any of them, so first-time installs always fail.

**Changes**:
- Add Helm `lookup` + `fail` guards in `providerconfigs.yaml` — when `providerConfigs.install=true` but CRDs are missing, users get an actionable error with exact `kubectl wait` + `helm upgrade` commands instead of `resource mapping not found`
- Default `providerConfigs.install` to `false` (two-step install is inherent to Crossplane)
- Fix `function-asya-flavors` version: fall back to `Chart.AppVersion` instead of stale hardcoded `0.5.3` (never bumped since initial commit)
- Update EKS docs with two-step install pattern (quickstart and GKE already had it)

**Also found**: v1.0.1 release images were never published because the release description was missing `MAJOR_VERSION_BUMP_CONFIRMED` — the major version guard in `release.yml` blocked the `build-and-publish` job.

## Test plan

- [x] `helm template` with `providerConfigs.install=false` — no ProviderConfig rendered
- [x] `helm template` with `providerConfigs.install=true` — clear fail message with instructions
- [x] `function-asya-flavors` resolves to `Chart.AppVersion` when `flavorsVersion` is empty
- [x] Reproduced #402 on EKS (aimc-test cluster) — confirmed two-step workaround works
- [ ] CI passes