### PR TITLE
fix(ci): only require major version confirmation on actual major bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: Setup environment
       uses: ./.github/actions/setup-env
@@ -40,10 +42,11 @@ jobs:
           exit 1
         fi
         MAJOR=$(echo "$TAG" | cut -d. -f1 | tr -d 'v')
-        if [ "$MAJOR" -ge 1 ]; then
-          BODY="${{ github.event.release.body }}"
-          if ! echo "$BODY" | grep -q 'MAJOR_VERSION_BUMP_CONFIRMED'; then
-            echo "::error::Major version bump (${TAG}) requires 'MAJOR_VERSION_BUMP_CONFIRMED' in the release description. This prevents accidental major releases."
+        PREV_TAG=$(git tag -l 'v*.*.*' | sort -V | grep -B1 "^${TAG}$" | head -1)
+        PREV_MAJOR=$(echo "${PREV_TAG:-v0.0.0}" | cut -d. -f1 | tr -d 'v')
+        if [ "$MAJOR" -gt "$PREV_MAJOR" ]; then
+          if ! echo "${{ github.event.release.body }}" | grep -q 'MAJOR_VERSION_BUMP_CONFIRMED'; then
+            echo "::error::Major version bump (${PREV_TAG:-none} -> ${TAG}). Add 'MAJOR_VERSION_BUMP_CONFIRMED' to the release description."
             exit 1
           fi
         fi


### PR DESCRIPTION
## Problem

The release workflow in `.github/workflows/release.yml` had a bug in the major version bump guard. It checked if `MAJOR >= 1` and required `MAJOR_VERSION_BUMP_CONFIRMED` in the release description. This blocked **every** release with major version >= 1 (e.g. v1.0.1, v1.0.2), not just actual major version bumps.

## Solution

The guard now compares the major version of the current tag against the major version of the most recent previous release tag. It only requires `MAJOR_VERSION_BUMP_CONFIRMED` when the major version actually increases (e.g. 0.x.x → 1.x.x, or 1.x.x → 2.x.x).

## Changes

- Fetch previous release tag using `gh release list`
- Extract major version from both current and previous tags
- Only require confirmation when current major > previous major
- Handle edge case where there's no previous release (first release ever)

## Testing

This fix should allow patch/minor releases (e.g. v1.0.1, v1.0.2, v1.1.0) to pass through without requiring the confirmation token, while still protecting against accidental major version bumps (e.g. v1.x.x → v2.0.0).