### PR TITLE
fix(ci): remove fetch-tags from checkout — conflicts with release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-tags: true
 
     - name: Setup environment
       uses: ./.github/actions/setup-env


### PR DESCRIPTION
Fixes v1.0.3, v1.0.4, v1.0.5 release failures.

`fetch-tags: true` on `actions/checkout@v4` conflicts with release-triggered
workflows — the checkout ref IS the tag, so fetching it again fails with
`Cannot fetch both <sha> and refs/tags/vX.Y.Z`.

One-line fix: remove `fetch-tags: true`. Tags are already fetched in the
validation step via `git fetch --tags`.