### PR TITLE
docs(setup): EKS install guide — RBAC, missing values, troubleshooting

### DIFF
--- a/docs/setup/start-aws-eks.md
+++ b/docs/setup/start-aws-eks.md
@@ -201,6 +201,20 @@ helm install crossplane crossplane-stable/crossplane \
   --namespace crossplane-system --create-namespace
 ```
 
+> **Custom namespace**: If you install Crossplane in a namespace other than
+> `crossplane-system` (e.g. `asya-system`), you must grant the Kubernetes
+> provider cross-namespace access. After the provider is Healthy, create a
+> ClusterRoleBinding:
+>
+> ```bash
+> kubectl create clusterrolebinding provider-kubernetes-admin \
+>   --clusterrole=cluster-admin \
+>   --serviceaccount=<YOUR_NAMESPACE>:provider-kubernetes
+> ```
+>
+> Without this, the provider cannot create Deployments in actor namespaces
+> and AsyncActors will remain in `Creating` state.
+
 ### 2. Configure Crossplane Values
 
 ```yaml
@@ -209,11 +223,14 @@ providers:
   aws:
     enabled: true   # opt-in: disabled by default
 
+awsRegion: us-east-1
+awsAccountId: "123456789012"   # required for KEDA SQS trigger queue URLs
+actorNamespace: default        # namespace where AsyncActors will be created
+
 irsa:
   enabled: true     # opt-in: disabled by default
-  roleArnPattern: "arn:aws:iam::ACCOUNT_ID:role/asya-actors-{namespace}"
+  roleArnPattern: "arn:aws:iam::123456789012:role/asya-actors-{namespace}"
 
-awsRegion: us-east-1
 awsProviderConfig:
   name: default
   credentialsSource: Secret
@@ -351,6 +368,33 @@ kubectl get pods -l asya.sh/actor=my-actor
 aws sqs list-queues | grep asya-my-actor
 kubectl get sqsqueue
 ```
+
+## Troubleshooting
+
+### ProviderConfig CRD not found during install
+
+The chart uses a two-step install. If you see `no matches for kind "ProviderConfig"`,
+install with `--set providerConfigs.install=false` first, wait for providers, then
+upgrade with `providerConfigs.install=true`. See Step 3 above.
+
+### AsyncActor stuck in Creating
+
+Check the Crossplane Object resource for RBAC errors:
+
+```bash
+kubectl get objects.kubernetes.crossplane.io -l crossplane.io/composite=$(
+  kubectl get asyncactor <name> -n <ns> -o jsonpath='{.spec.resourceRef.name}'
+) -o yaml | grep -A5 "message:"
+```
+
+If you see `"deployments" is forbidden`, the Kubernetes provider needs cross-namespace
+RBAC. See the note under Step 1 above.
+
+### RabbitMQ: sidecar stuck in backoff
+
+Known issue (#384): if the RabbitMQ queue does not exist when the sidecar starts, the
+AMQP channel breaks on the first 404 and subsequent retries cannot recover. Restart
+the pod after the queue is created. Fix tracked in #372 and #384.
 
 ## Cost Optimization
 

--- a/docs/setup/start-aws-eks.md
+++ b/docs/setup/start-aws-eks.md
@@ -202,15 +202,9 @@ helm install crossplane crossplane-stable/crossplane \
 ```
 
 > **Custom namespace**: If you install Crossplane in a namespace other than
-> `crossplane-system` (e.g. `asya-system`), you must grant the Kubernetes
-> provider cross-namespace access. After the provider is Healthy, create a
-> ClusterRoleBinding:
->
-> ```bash
-> kubectl create clusterrolebinding provider-kubernetes-admin \
->   --clusterrole=cluster-admin \
->   --serviceaccount=<YOUR_NAMESPACE>:provider-kubernetes
-> ```
+> `crossplane-system` (e.g. `asya-system`), set `crossplaneNamespace` in
+> your `crossplane-values.yaml` (see Step 2). The chart creates the required
+> ClusterRoleBinding automatically.
 >
 > Without this, the provider cannot create Deployments in actor namespaces
 > and AsyncActors will remain in `Creating` state.
@@ -224,8 +218,9 @@ providers:
     enabled: true   # opt-in: disabled by default
 
 awsRegion: us-east-1
-awsAccountId: "123456789012"   # required for KEDA SQS trigger queue URLs
-actorNamespace: default        # namespace where AsyncActors will be created
+awsAccountId: "123456789012"    # required for KEDA SQS trigger queue URLs
+actorNamespace: default         # namespace where AsyncActors will be created
+# crossplaneNamespace: asya-system  # set if Crossplane is not in crossplane-system
 
 irsa:
   enabled: true     # opt-in: disabled by default
@@ -387,8 +382,8 @@ kubectl get objects.kubernetes.crossplane.io -l crossplane.io/composite=$(
 ) -o yaml | grep -A5 "message:"
 ```
 
-If you see `"deployments" is forbidden`, the Kubernetes provider needs cross-namespace
-RBAC. See the note under Step 1 above.
+If you see `"deployments" is forbidden`, set `crossplaneNamespace` in your values to
+match the namespace where Crossplane is installed. See the note under Step 1 above.
 
 ### RabbitMQ: sidecar stuck in backoff
 


### PR DESCRIPTION
## Summary

Updates EKS install guide based on hands-on testing on aimc-test cluster.

- **RBAC warning**: Installing Crossplane in a non-default namespace (e.g. `asya-system`) requires a ClusterRoleBinding for `provider-kubernetes`. Without it, AsyncActors stay in `Creating` with a forbidden error. Added callout under Step 1.
- **Missing values**: `awsAccountId` and `actorNamespace` were not in the example `crossplane-values.yaml` but are required for KEDA SQS triggers and runtime ConfigMap placement.
- **Troubleshooting section**: Added for ProviderConfig CRD errors (#402), AsyncActor stuck in Creating (RBAC), and RabbitMQ sidecar backoff (#384).

Findings from EKS testing also reported on: #402, #372, #381, #384.

## Test plan

- [x] Tested full install path on EKS aimc-test cluster
- [ ] CI passes