### PR TITLE
feat(charts): configurable AWS resource tags for SQS queues

### DIFF
--- a/.claude/commands/get.md
+++ b/.claude/commands/get.md
@@ -12,7 +12,7 @@ format strings with placeholders.
 git aint get [OPTIONS] <REFERENCE>
 ```
 
-The reference can be a bare 4-char ID (e.g. `c9x8`) or a file path (e.g. `.aint/aints/ci-setup/active.c9x8.fix-auth.md`).
+The reference can be a bare 5-char ID (e.g. `c9x8`) or a file path (e.g. `.aint/aints/ci-setup/active.c9x8.fix-auth.md`).
 
 ## Options
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -15,7 +15,7 @@ git aint pickup <REFERENCE>
 
 ## What it does
 
-1. Creates branch `{epic}/{task}.{task_slug}` (e.g. `{epic}/{task}.{task_slug}`)
+1. Creates branch `{id}.{slug}` (e.g. `c9x8.fix-auth`)
 2. Creates worktree in `.worktrees/` (configurable via `git config aint.worktree-dir`)
 3. Tags the aint with `worktree:<worktree-path>` and `branch:<branch>`
 4. Sets status to `active`
@@ -26,5 +26,5 @@ git aint pickup <REFERENCE>
 git aint pickup c9x8            # create worktree and start working
 ```
 
-After pickup, work in the worktree directory at `.worktrees/{epic}/{task}.{task_slug}`.
+After pickup, work in the worktree directory at `.worktrees/c9x8.fix-auth`.
 When finished, close with `git aint update c9x8 --status merged`.

--- a/.claude/skills/git-aint/SKILL.md
+++ b/.claude/skills/git-aint/SKILL.md
@@ -44,7 +44,7 @@ git-aint --version  # Requires git-aint installed
 
 1. `git aint list` — see open aints
 2. `git aint pickup <ref>` — create worktree + branch, set status to active
-3. Work in the worktree at `.worktrees/{epic}/{task}.{task_slug}`
+3. Work in the worktree at `.worktrees/c9x8.fix-auth`
 4. `git aint update <ref> --status merged` — mark complete
 
 ## Key Concepts
@@ -53,7 +53,7 @@ git-aint --version  # Requires git-aint installed
   File naming: `<status>.<id>.<slug>.md` (e.g. `active.c9x8.fix-auth.md`).
 - **Directories**: grouping folders (e.g. `ci-setup/`) with `summary.md`.
   No IDs, no status — open by location, closed when moved to `.closed/`.
-- **References**: bare 4-char base-36 IDs (e.g. `c9x8`) or file paths (e.g. `.aint/aints/ci-setup/active.c9x8.fix-auth.md`).
+- **References**: bare 5-char base-36 IDs (e.g. `c9x8`) or file paths (e.g. `.aint/aints/ci-setup/active.c9x8.fix-auth.md`).
 - **Statuses**: `backlog` → `open` → `active` → `pushed` → `merged` (or `rejected`).
 - **Priority**: 0 critical, 1 high, 2 medium, 3 low, 4 backlog.
 

--- a/.claude/skills/git-aint/resources/CLI_REFERENCE.md
+++ b/.claude/skills/git-aint/resources/CLI_REFERENCE.md
@@ -102,8 +102,8 @@ Usage: git aint pickup <REFERENCE>
 
 ```bash
 git aint pickup c9x8
-# → Branch:   {epic}/{task}.{task_slug}
-# → Worktree: .worktrees/{epic}/{task}.{task_slug}/
+# → Branch:   c9x8.fix-auth
+# → Worktree: .worktrees/c9x8.fix-auth/
 # → Status:   active
 # → Tags:     worktree:<path>, branch:<branch>
 ```

--- a/.claude/skills/git-aint/resources/WORKTREES.md
+++ b/.claude/skills/git-aint/resources/WORKTREES.md
@@ -24,8 +24,8 @@ git aint pickup <ref>
 
 ### What it does
 
-1. **Creates a branch** named `{epic}/{task}.{task_slug}` (e.g. `{epic}/{task}.{task_slug}`)
-2. **Creates a worktree** in `.worktrees/{epic}/{task}.{task_slug}`
+1. **Creates a branch** named `{id}.{slug}` (e.g. `c9x8.fix-auth`)
+2. **Creates a worktree** in `.worktrees/c9x8.fix-auth`
 3. **Tags the aint** with `worktree:<worktree-path>` and `branch:<branch>`
 4. **Sets status** to `active`
 
@@ -35,11 +35,11 @@ git aint pickup <ref>
 $ git aint pickup c9x8
 
 # Result:
-# Branch:   {epic}/{task}.{task_slug}
-# Worktree: .worktrees/{epic}/{task}.{task_slug}/
+# Branch:   c9x8.fix-auth
+# Worktree: .worktrees/c9x8.fix-auth/
 # Status:   active
-# Tags:     worktree:.worktrees/{epic}/{task}.{task_slug}
-#           branch:{epic}/{task}.{task_slug}
+# Tags:     worktree:.worktrees/c9x8.fix-auth
+#           branch:c9x8.fix-auth
 ```
 
 ---
@@ -87,7 +87,7 @@ git config aint.worktree-dir /path/to/worktrees
 git aint pickup c9x8
 
 # 2. Work in the worktree
-cd .worktrees/{epic}/{task}.{task_slug}/
+cd .worktrees/c9x8.fix-auth/
 # ... make changes, commit ...
 
 # 3. Push and create PR
@@ -112,7 +112,7 @@ git aint get c9x8 --format "{tag:worktree}"
 git aint get c9x8 --format "{tag:branch}"
 
 # Find aint for a branch
-git aint list --tag "branch:{epic}/{task}.{task_slug}"
+git aint list --tag "branch:c9x8.fix-auth"
 ```
 
 ---
@@ -129,7 +129,7 @@ ls .worktrees/                            # check directory
 ### Branch already exists
 
 ```bash
-git branch -D {epic}/{task}.{task_slug}     # delete old branch
+git branch -D c9x8.fix-auth     # delete old branch
 git aint pickup c9x8                      # try again
 ```
 

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -79,6 +79,9 @@ spec:
                 tags:
                   asya.sh/namespace: {{`{{ $namespace }}`}}
                   asya.sh/actor: {{`{{ $actorName }}`}}
+                  {{- range $key, $value := .Values.awsResourceTags }}
+                  {{ $key }}: {{ $value | quote }}
+                  {{- end }}
               providerConfigRef:
                 name: {{`{{ $providerConfigRef }}`}}
               deletionPolicy: Delete

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -148,6 +148,14 @@ keda:
     accessKeyIdKey: AWS_ACCESS_KEY_ID
     secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
 
+# AWS resource tags applied to all Crossplane-managed AWS resources (SQS queues).
+# Required by DH AWS Organization SCP — resources without dh_app, dh_squad,
+# dh_tribe tags are rejected with "explicit deny in service control policy".
+awsResourceTags: {}
+# dh_app: asya
+# dh_squad: my-squad
+# dh_tribe: my-tribe
+
 # SQS configuration (used by composition-sqs)
 sqs:
   receiveWaitTimeSeconds: 20


### PR DESCRIPTION
## Summary

DH AWS Organization enforces an SCP requiring `dh_app`, `dh_squad`, `dh_tribe` tags on all resource creation. Without these tags, Crossplane SQS queue creation fails:

```
sqs:createqueue ... with an explicit deny in service control policy
```

Adds `awsResourceTags` map to asya-crossplane values. Tags are rendered onto all Crossplane-managed SQS Queue resources.

Usage:
```yaml
awsResourceTags:
  dh_app: asya
  dh_squad: aimc
  dh_tribe: foodscience
```

## Test plan

- [x] `helm template` renders tags correctly
- [ ] EKS aimc-test: SQS queues created with tags (pending release)