### PR TITLE
feat(charts): configurable AWS resource tags for SQS queues

### DIFF
--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -79,6 +79,9 @@ spec:
                 tags:
                   asya.sh/namespace: {{`{{ $namespace }}`}}
                   asya.sh/actor: {{`{{ $actorName }}`}}
+                  {{- range $key, $value := .Values.awsResourceTags }}
+                  {{ $key }}: {{ $value | quote }}
+                  {{- end }}
               providerConfigRef:
                 name: {{`{{ $providerConfigRef }}`}}
               deletionPolicy: Delete

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -148,6 +148,14 @@ keda:
     accessKeyIdKey: AWS_ACCESS_KEY_ID
     secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
 
+# AWS resource tags applied to all Crossplane-managed AWS resources (SQS queues).
+# Required by DH AWS Organization SCP — resources without dh_app, dh_squad,
+# dh_tribe tags are rejected with "explicit deny in service control policy".
+awsResourceTags: {}
+# dh_app: asya
+# dh_squad: my-squad
+# dh_tribe: my-tribe
+
 # SQS configuration (used by composition-sqs)
 sqs:
   receiveWaitTimeSeconds: 20


### PR DESCRIPTION
## Summary

DH AWS Organization enforces an SCP requiring `dh_app`, `dh_squad`, `dh_tribe` tags on all resource creation. Without these tags, Crossplane SQS queue creation fails:

```
sqs:createqueue ... with an explicit deny in service control policy
```

Adds `awsResourceTags` map to asya-crossplane values. Tags are rendered onto all Crossplane-managed SQS Queue resources.

Usage:
```yaml
awsResourceTags:
  dh_app: asya
  dh_squad: aimc
  dh_tribe: foodscience
```

## Test plan

- [x] `helm template` renders tags correctly
- [ ] EKS aimc-test: SQS queues created with tags (pending release)