### PR TITLE
docs: add frontmatter descriptions for agent discovery, fix mkdocs nav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,11 @@ A2A task state mapping: `pending` → `submitted`, `running` → `working`, `suc
 2. Work exclusively in the worktree
 3. Commit, push, create a PR — never merge directly
 
+### DCO Sign-off
+
+All commits **must** include a DCO (Developer Certificate of Origin) sign-off line.
+Always use `git commit -s` (or `git commit --signoff`). CI will reject unsigned commits.
+
 ### Command Hierarchy
 
 1. **Prefer**: `make <target>`
@@ -274,7 +279,7 @@ grep -rn "^description:" docs/ --include="*.md"
 grep -r "description:.*sidecar" docs/ --include="*.md" -l
 
 # Find docs about a concept or pattern
-grep -r "description:.*fan-out\|fan-in\|streaming" docs/ --include="*.md" -l
+grep -rE "description:.*(fan-out|fan-in|streaming)" docs/ --include="*.md" -l
 ```
 
 **Doc sections** (`docs/`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,42 @@ requested. Updating existing docs to reflect code changes is fine.
 - Mirrored guides in `usage/` and `setup/` must cross-link each other.
 - `docs/plans/` is gitignored and must never be committed. Use aint for work tracking.
 
+### Documentation Discovery
+
+Every file in `docs/` has a YAML frontmatter `description` field — a grep-friendly one-liner with
+searchable keywords. Use this to find the right doc fast:
+
+```bash
+# Search for a topic across all doc descriptions (fastest)
+grep -r "description:.*routing" docs/ --include="*.md" -l
+
+# Browse all descriptions at a glance
+grep -rn "^description:" docs/ --include="*.md"
+
+# Find docs about a specific component
+grep -r "description:.*sidecar" docs/ --include="*.md" -l
+
+# Find docs about a concept or pattern
+grep -r "description:.*fan-out\|fan-in\|streaming" docs/ --include="*.md" -l
+```
+
+**Doc sections** (`docs/`):
+
+| Section | Audience | Content |
+|---------|----------|---------|
+| `concepts/` | Everyone | What Asya is, architectural ideas, design principles |
+| `setup/` | Platform engineers | Deployment, Helm config, autoscaling, observability |
+| `usage/` | Data scientists | Tutorials, handler patterns, agentic patterns, debugging |
+| `reference/` | Both | Component specs, API specs, env vars, transport/storage config |
+| `comparisons/` | Evaluators | Asya vs other frameworks (Temporal, LangGraph, Ray, etc.) |
+| `contributing/` | Contributors | Test strategies, cross-component architecture decisions |
+
+**Naming conventions**: `start-*` = getting started tutorials, `guide-*` = how-to guides,
+`ops-*` = operations/debugging, `core-*` = core components, `lab-*` = developer tools,
+`as-*` = category comparisons, `vs-*` = 1:1 deep comparisons.
+
+When you need documentation context, grep descriptions first — don't read files speculatively.
+
 ### Code Comment Policy
 
 Never use transitional comments ("instead of", "increased from", "no need to"). Comments explain

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+description: "Documentation home: navigation hub for data scientists, platform engineers, and contributors"
+---
+
 # Home
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,7 @@
+---
+description: "Architecture overview: actor mesh, pod anatomy, message flow, gateway, crossplane, deployment patterns"
+---
+
 # Architecture
 
 Asya is a Kubernetes-native async actor mesh. All components are designed around one

--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -1,3 +1,7 @@
+---
+description: "Comparisons index: Asya vs workflow orchestrators, actor frameworks, agentic frameworks, ML tools"
+---
+
 # Comparisons
 
 How does 🎭 Asya compare to other tools in the ecosystem? Each page provides honest,

--- a/docs/comparisons/as-actor-framework.md
+++ b/docs/comparisons/as-actor-framework.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs Erlang/OTP, Akka, Orleans, Dapr — actor model implementations"
+---
+
 # Actor Frameworks
 
 **Erlang/OTP, Akka/Pekko, Microsoft Orleans, Dapr**

--- a/docs/comparisons/as-agentic-framework.md
+++ b/docs/comparisons/as-agentic-framework.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs LangGraph, CrewAI, Google ADK, AutoGen, KAgent — AI agent frameworks"
+---
+
 # Agentic Frameworks
 
 **LangGraph, CrewAI, Google ADK, AutoGen, KAgent**

--- a/docs/comparisons/as-ai-serving.md
+++ b/docs/comparisons/as-ai-serving.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs KServe, KAITO, KubeAI, vLLM, LLM-d — AI/ML model serving"
+---
+
 # AI/ML Serving
 
 **KServe, KAITO, KubeAI, vLLM/SGLang, LLM-d**

--- a/docs/comparisons/as-k8s-scheduler.md
+++ b/docs/comparisons/as-k8s-scheduler.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs Kueue, Run.ai, Volcano — Kubernetes GPU job schedulers"
+---
+
 # K8s Job Schedulers
 
 **Kueue, Run.ai, Volcano**

--- a/docs/comparisons/as-ml-pipeline-tool.md
+++ b/docs/comparisons/as-ml-pipeline-tool.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs Kubeflow Pipelines, Flyte, Metaflow, ZenML — ML pipeline tools"
+---
+
 # ML Pipeline Tools
 
 **Kubeflow Pipelines, Flyte, Metaflow, ZenML**

--- a/docs/comparisons/as-stream-processing.md
+++ b/docs/comparisons/as-stream-processing.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs Flink, Kafka Streams, Spark Streaming — stream processing frameworks"
+---
+
 # Stream Processing
 
 **Apache Flink, Kafka Streams, Spark Streaming**

--- a/docs/comparisons/as-workflow-orchestrator.md
+++ b/docs/comparisons/as-workflow-orchestrator.md
@@ -1,3 +1,7 @@
+---
+description: "Comparison: Asya vs Temporal, Argo Workflows, Airflow, Prefect, Dagster — orchestration approaches"
+---
+
 # Workflow Orchestrators
 
 **Temporal, Argo Workflows, Apache Airflow, Prefect, Dagster**

--- a/docs/comparisons/vs-dapr.md
+++ b/docs/comparisons/vs-dapr.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs Dapr — both inject sidecars, different architecture philosophy"
+---
+
 # vs Dapr
 
 ## TL;DR

--- a/docs/comparisons/vs-google-adk.md
+++ b/docs/comparisons/vs-google-adk.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs Google ADK — output_key pattern vs envelope routing for agents"
+---
+
 # vs Google ADK
 
 ## TL;DR

--- a/docs/comparisons/vs-kagent.md
+++ b/docs/comparisons/vs-kagent.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs KAgent — CNCF K8s-native agent CRDs vs actor mesh CRDs"
+---
+
 # vs KAgent
 
 ## TL;DR

--- a/docs/comparisons/vs-kubeflow-pipelines.md
+++ b/docs/comparisons/vs-kubeflow-pipelines.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs Kubeflow Pipelines — Argo DAGs vs actor mesh for ML pipelines"
+---
+
 # vs Kubeflow Pipelines
 
 ## TL;DR

--- a/docs/comparisons/vs-langgraph.md
+++ b/docs/comparisons/vs-langgraph.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs LangGraph — in-process graph vs distributed actor mesh for agents"
+---
+
 # vs LangGraph
 
 ## TL;DR

--- a/docs/comparisons/vs-ray-serve.md
+++ b/docs/comparisons/vs-ray-serve.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs Ray Serve — Ray cluster vs K8s-native mesh for ML serving"
+---
+
 # vs Ray Serve
 
 ## TL;DR

--- a/docs/comparisons/vs-temporal.md
+++ b/docs/comparisons/vs-temporal.md
@@ -1,3 +1,7 @@
+---
+description: "Deep comparison: Asya vs Temporal — centralized replay vs decentralized queue-based routing"
+---
+
 # vs Temporal
 
 ## TL;DR

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,3 +1,7 @@
+---
+description: "Index of core concepts: actor mesh, routing, virtual actors, flow compiler, transports, storage, observability"
+---
+
 # Core Concepts
 
 Asya 🎭 rests on a small set of ideas. Each page below explains one

--- a/docs/concepts/actor-mesh.md
+++ b/docs/concepts/actor-mesh.md
@@ -1,3 +1,7 @@
+---
+description: "Choreography pattern: actors communicate via queues, scale independently, no central orchestrator"
+---
+
 # Actor Mesh
 
 ## What is an Actor Mesh?

--- a/docs/concepts/agentic-native.md
+++ b/docs/concepts/agentic-native.md
@@ -1,3 +1,7 @@
+---
+description: "Agentic patterns: AI agent swarms as distributed actors with streaming, pause/resume, fan-out"
+---
+
 # Agentic Native
 
 The actor mesh is the most general agentic pattern: each AI agent runs as an

--- a/docs/concepts/built-in-resiliency.md
+++ b/docs/concepts/built-in-resiliency.md
@@ -1,3 +1,7 @@
+---
+description: "Resiliency: durable queues, configurable retry policies, DLQ routing, SLA deadlines, timeouts"
+---
+
 # Built-in Resiliency
 
 Messages in Asya are durably queued. A pod can be evicted, restarted, or

--- a/docs/concepts/developer-experience.md
+++ b/docs/concepts/developer-experience.md
@@ -1,3 +1,7 @@
+---
+description: "Developer experience: any OCI image, GitOps, CI/CD, local Kind testing, CLI tools"
+---
+
 # Developer Experience
 
 Asya provides CLI tools and local testing workflows that let developers iterate

--- a/docs/concepts/dynamic-routing.md
+++ b/docs/concepts/dynamic-routing.md
@@ -1,3 +1,7 @@
+---
+description: "Runtime routing: actors rewrite route.next at runtime for branches, loops, human-in-the-loop"
+---
+
 # Dynamic Routing
 
 In static pipeline frameworks like Airflow or Argo Workflows, the execution

--- a/docs/concepts/flow-compiler.md
+++ b/docs/concepts/flow-compiler.md
@@ -1,3 +1,7 @@
+---
+description: "Flow DSL: Python control flow (if/else, gather) compiled to flat actor graphs via CPS transform"
+---
+
 # Flow Compiler
 
 The Flow Compiler lets you describe multi-actor pipelines as familiar Python

--- a/docs/concepts/http-gateway.md
+++ b/docs/concepts/http-gateway.md
@@ -1,3 +1,7 @@
+---
+description: "HTTP gateway: bridges async actor mesh with synchronous HTTP, A2A protocol, MCP tools"
+---
+
 # HTTP Gateway
 
 The actor mesh is asynchronous by design — messages flow through queues, and

--- a/docs/concepts/kubernetes-native.md
+++ b/docs/concepts/kubernetes-native.md
@@ -1,3 +1,7 @@
+---
+description: "Kubernetes native: AsyncActor CRD, kubectl/Helm/GitOps, RBAC, Crossplane Compositions"
+---
+
 # Kubernetes Native
 
 Asya is not a layer on top of Kubernetes — it is Kubernetes. Actors are Custom

--- a/docs/concepts/message-knows-the-way.md
+++ b/docs/concepts/message-knows-the-way.md
@@ -1,3 +1,7 @@
+---
+description: "Envelope routing: route embedded in message (prev/curr/next), no external router or coordinator"
+---
+
 # Message Knows the Way
 
 In most pipeline frameworks, a central coordinator decides where each message

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -1,3 +1,7 @@
+---
+description: "Observability: OpenTelemetry tracing, Prometheus metrics, structured logging, Grafana dashboards"
+---
+
 # Built-in Observability
 
 In a distributed actor mesh, understanding what happened and where requires

--- a/docs/concepts/pluggable-storage.md
+++ b/docs/concepts/pluggable-storage.md
@@ -1,3 +1,7 @@
+---
+description: "Pluggable storage: S3, GCS, Redis, NATS KV backends for state proxy virtual actor memory"
+---
+
 # Pluggable Storage
 
 ## State Proxy Connectors

--- a/docs/concepts/pluggable-transport.md
+++ b/docs/concepts/pluggable-transport.md
@@ -1,3 +1,7 @@
+---
+description: "Pluggable transports: swap SQS, RabbitMQ, or Pub/Sub via Crossplane without code changes"
+---
+
 # Pluggable Transports
 
 Asya separates message transport from application logic. The same handler code

--- a/docs/concepts/scale-to-zero.md
+++ b/docs/concepts/scale-to-zero.md
@@ -1,3 +1,7 @@
+---
+description: "Autoscaling: KEDA watches queue depth, scale to zero between batches, GPU cost optimization"
+---
+
 # Scale Zero to Infinity
 
 Asya actors scale independently based on their own queue depth. When there is no

--- a/docs/concepts/separation-of-concerns.md
+++ b/docs/concepts/separation-of-concerns.md
@@ -1,3 +1,7 @@
+---
+description: "Role separation: data scientists write Python handlers, platform engineers configure infrastructure"
+---
+
 # Separation of Concerns
 
 Asya enforces a clean boundary between application logic and infrastructure

--- a/docs/concepts/virtual-actors.md
+++ b/docs/concepts/virtual-actors.md
@@ -1,3 +1,7 @@
+---
+description: "Virtual actors: stateless Deployments with optional persistent memory via state proxy sidecar"
+---
+
 # Virtual Actors
 
 Asya actors are stateless Kubernetes Deployments by design. They carry no

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,3 +1,7 @@
+---
+description: "Contributing index: test strategies, architecture decisions, cross-component concerns"
+---
+
 # Contributing
 
 Technical notes for contributors working on the Asya framework. These documents capture implementation details, test strategies, and non-obvious decisions.

--- a/docs/contributing/testing-a2a.md
+++ b/docs/contributing/testing-a2a.md
@@ -1,3 +1,7 @@
+---
+description: "Test strategy: A2A protocol testing across all test levels"
+---
+
 # Testing: A2A Protocol
 
 How the A2A (Agent-to-Agent) protocol implementation in `asya-gateway` is tested

--- a/docs/contributing/testing-state-proxy.md
+++ b/docs/contributing/testing-state-proxy.md
@@ -1,3 +1,7 @@
+---
+description: "Test strategy: state proxy backends across unit, component, integration, E2E test levels"
+---
+
 # Testing: State Proxy / Storage Backends
 
 How storage backends (S3/GCS/Redis) are exercised across all test levels.

--- a/docs/contributing/testing-transport.md
+++ b/docs/contributing/testing-transport.md
@@ -1,3 +1,7 @@
+---
+description: "Test strategy: transport backends across unit, component, integration, E2E test levels"
+---
+
 # Testing: Transport Backends
 
 How message transport (SQS, Pub/Sub, RabbitMQ) is exercised across all test levels.

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -1,3 +1,7 @@
+---
+description: "Motivation: why Asya exists, problem statement, AI pipeline scalability challenges"
+---
+
 # Motivation
 
 ## The Starting Point

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,3 +1,7 @@
+---
+description: "Reference index: component specs, transport configs, state proxy connectors, environment variables"
+---
+
 # Reference
 
 Accurate technical descriptions — specs, configuration tables, API surfaces. Shared by both actor authors and platform engineers.

--- a/docs/reference/components/README.md
+++ b/docs/reference/components/README.md
@@ -1,3 +1,7 @@
+---
+description: "Components index: sidecar, runtime, gateway, crew, crossplane, state proxy, CLI, flow compiler"
+---
+
 # Components
 
 ## Core — Runtime Infrastructure

--- a/docs/reference/components/core-actor.md
+++ b/docs/reference/components/core-actor.md
@@ -1,3 +1,7 @@
+---
+description: "AsyncActor CRD: status model, lifecycle phases, Crossplane composition behavior"
+---
+
 # Actor
 
 ![AsyncActor pod anatomy: sidecar + runtime + optional state proxy](../../website/img/actor-anatomy.png)

--- a/docs/reference/components/core-crew.md
+++ b/docs/reference/components/core-crew.md
@@ -1,3 +1,7 @@
+---
+description: "Crew system actors: x-sink (results), x-sump (DLQ), x-pause/x-resume (human-in-the-loop)"
+---
+
 # Crew
 
 System actors with reserved roles for framework-level tasks.

--- a/docs/reference/components/core-crossplane.md
+++ b/docs/reference/components/core-crossplane.md
@@ -1,3 +1,7 @@
+---
+description: "Crossplane: XRD, Compositions, provider configs, inline sidecar rendering, queue auto-creation"
+---
+
 # Crossplane
 
 ## Overview

--- a/docs/reference/components/core-gateway.md
+++ b/docs/reference/components/core-gateway.md
@@ -1,3 +1,7 @@
+---
+description: "Gateway (Go): MCP/A2A HTTP bridge, api/mesh modes, task state, PostgreSQL, SSE streaming"
+---
+
 # Gateway
 
 ## Responsibilities

--- a/docs/reference/components/core-runtime.md
+++ b/docs/reference/components/core-runtime.md
@@ -1,3 +1,7 @@
+---
+description: "Runtime (Python): handler execution, Unix socket protocol, generator/function dispatch, ABI"
+---
+
 # Runtime
 
 ## Responsibilities

--- a/docs/reference/components/core-sidecar.md
+++ b/docs/reference/components/core-sidecar.md
@@ -1,3 +1,7 @@
+---
+description: "Sidecar (Go): queue polling, envelope routing, retry policies, fan-out, progress reporting, metrics"
+---
+
 # Sidecar
 
 Detailed architecture of the 🎭 Actor Sidecar. Please also refer to code documentation [`src/asya-sidecar/README.md`](https://github.com/deliveryhero/asya/blob/main/src/asya-sidecar/README.md)

--- a/docs/reference/components/core-state-proxy.md
+++ b/docs/reference/components/core-state-proxy.md
@@ -1,3 +1,7 @@
+---
+description: "State proxy (Go): virtual filesystem sidecar, /state/ paths, S3/GCS/Redis/NATS KV backends"
+---
+
 # State Proxy
 
 ## Overview

--- a/docs/reference/components/lab-cli.md
+++ b/docs/reference/components/lab-cli.md
@@ -1,3 +1,6 @@
+---
+description: "CLI reference: asya mcp, asya flow, asya init, asya build, asya k apply commands"
+---
 
 # CLI
 

--- a/docs/reference/components/lab-flow-compiler.md
+++ b/docs/reference/components/lab-flow-compiler.md
@@ -1,3 +1,7 @@
+---
+description: "Flow compiler: Python DSL to actor graph, CPS transform, router generation, fan-out/fan-in"
+---
+
 # Flow Compiler
 
 This document describes the **compiler internals** — how the Flow DSL

--- a/docs/reference/credentials.md
+++ b/docs/reference/credentials.md
@@ -1,3 +1,7 @@
+---
+description: "Credentials mapping: auth configuration for all components (AWS, GCP, RabbitMQ, PostgreSQL)"
+---
+
 # Credentials and Secrets Reference
 
 How authentication works across Asya components. This page maps every

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -1,3 +1,6 @@
+---
+description: "Environment variables: consolidated reference for all components (sidecar, runtime, gateway, crew, state proxy)"
+---
 
 # Environment Variables
 

--- a/docs/reference/scalers/pubsub.md
+++ b/docs/reference/scalers/pubsub.md
@@ -1,3 +1,7 @@
+---
+description: "Pub/Sub external scaler: KEDA scaler for Pub/Sub, direct Pull API, replaces deprecated built-in"
+---
+
 # asya-scalers
 
 KEDA external scalers for Asya transport backends.

--- a/docs/reference/specs/README.md
+++ b/docs/reference/specs/README.md
@@ -1,3 +1,7 @@
+---
+description: "Specs index: envelope, CRD, ABI protocol, sidecar-runtime, gateway API, flow DSL, error handling"
+---
+
 # Specifications
 
 Protocols, interfaces, and formal specifications for the Asya framework.

--- a/docs/reference/specs/abi-protocol.md
+++ b/docs/reference/specs/abi-protocol.md
@@ -1,3 +1,7 @@
+---
+description: "ABI protocol: yield-based commands (GET/SET/DEL/FLY), path syntax, access control, type dispatch"
+---
+
 # ABI Protocol
 
 ## What is the ABI?

--- a/docs/reference/specs/asyncactor-crd.md
+++ b/docs/reference/specs/asyncactor-crd.md
@@ -1,3 +1,6 @@
+---
+description: "AsyncActor CRD spec: full field reference, compositionSelector, resiliency, transport, state proxy"
+---
 
 # AsyncActor CRD
 

--- a/docs/reference/specs/compiler-rules.md
+++ b/docs/reference/specs/compiler-rules.md
@@ -1,3 +1,7 @@
+---
+description: "Compiler rules spec: extensible rules for decorators, context managers, custom call patterns"
+---
+
 # Compiler Rules
 
 Formal specification for the compiler rules system — the extensible knowledge

--- a/docs/reference/specs/envelope.md
+++ b/docs/reference/specs/envelope.md
@@ -1,3 +1,7 @@
+---
+description: "Envelope spec: JSON structure, route (prev/curr/next), headers, status, fan-out ID semantics"
+---
+
 # Envelope
 
 ## Envelope Structure

--- a/docs/reference/specs/error-handling.md
+++ b/docs/reference/specs/error-handling.md
@@ -1,3 +1,7 @@
+---
+description: "Error handling spec: resiliency policies, retry rules, error routing, DLQ, onExhausted fallback"
+---
+
 # Error Handling
 
 Error routing specification for the Asya actor mesh. Covers policy exhaustion, DLQ handling, and the x-sink/x-sump termination chain.

--- a/docs/reference/specs/flow-dsl.md
+++ b/docs/reference/specs/flow-dsl.md
@@ -1,3 +1,6 @@
+---
+description: "Flow DSL spec: Python syntax rules, compilation semantics, fan-out/fan-in, conditional routing"
+---
 
 # Flow DSL
 

--- a/docs/reference/specs/gateway-api.md
+++ b/docs/reference/specs/gateway-api.md
@@ -1,3 +1,7 @@
+---
+description: "Gateway API spec: A2A endpoints, MCP endpoints, mesh callbacks, /stream/ SSE, auth middleware"
+---
+
 # Gateway API
 
 Complete reference for all `asya-gateway` HTTP endpoints. Routes are split across two deployments (api and mesh). See [core-gateway.md](../components/core-gateway.md) for deployment architecture and auth configuration.

--- a/docs/reference/specs/sidecar-runtime.md
+++ b/docs/reference/specs/sidecar-runtime.md
@@ -1,3 +1,7 @@
+---
+description: "Sidecar-runtime protocol: Unix socket framing, request/response format, timeout strategy"
+---
+
 # Sidecar-Runtime
 
 Communication between Asya sidecar (Go) and runtime (Python) uses **HTTP/1.1 over a Unix domain socket**.

--- a/docs/reference/specs/streaming-events.md
+++ b/docs/reference/specs/streaming-events.md
@@ -1,3 +1,7 @@
+---
+description: "Streaming spec: FLY events, SSE delivery, pg_notify cross-process, ephemeral vs persistent"
+---
+
 # Streaming Events Reference
 
 Complete reference for all streaming event types in Asya, how they flow through the

--- a/docs/reference/state-proxy-connectors/README.md
+++ b/docs/reference/state-proxy-connectors/README.md
@@ -1,3 +1,7 @@
+---
+description: "State proxy connectors index: S3, GCS, Redis, NATS KV storage backends for virtual actor state"
+---
+
 # State Proxy Connectors
 
 State proxy connectors are pluggable storage backends that give actors persistent state access via standard Python file operations.

--- a/docs/reference/state-proxy-connectors/gcs.md
+++ b/docs/reference/state-proxy-connectors/gcs.md
@@ -1,3 +1,7 @@
+---
+description: "GCS connector: Google Cloud Storage config for state proxy, bucket setup, Workload Identity"
+---
+
 # GCS
 
 Google Cloud Storage connector for state proxy.

--- a/docs/reference/state-proxy-connectors/nats-kv.md
+++ b/docs/reference/state-proxy-connectors/nats-kv.md
@@ -1,3 +1,7 @@
+---
+description: "NATS KV connector: NATS JetStream Key-Value config for state proxy, bucket setup"
+---
+
 # NATS KV
 
 NATS JetStream Key-Value connector for state proxy.

--- a/docs/reference/state-proxy-connectors/redis.md
+++ b/docs/reference/state-proxy-connectors/redis.md
@@ -1,3 +1,7 @@
+---
+description: "Redis connector: Redis config for state proxy, connection string, key prefix, TTL"
+---
+
 # Redis
 
 Redis key-value connector for state proxy with Check-And-Set consistency.

--- a/docs/reference/state-proxy-connectors/s3.md
+++ b/docs/reference/state-proxy-connectors/s3.md
@@ -1,3 +1,7 @@
+---
+description: "S3 connector: AWS S3/MinIO config for state proxy, bucket setup, IAM, endpoint override"
+---
+
 # S3
 
 AWS S3 and MinIO-compatible object storage connector for state proxy.

--- a/docs/reference/transports/README.md
+++ b/docs/reference/transports/README.md
@@ -1,3 +1,7 @@
+---
+description: "Transports index: pluggable message queue backends (SQS, RabbitMQ, Pub/Sub, Socket)"
+---
+
 # Transports
 
 Asya supports pluggable message queue transports for actor communication.

--- a/docs/reference/transports/pubsub.md
+++ b/docs/reference/transports/pubsub.md
@@ -1,3 +1,7 @@
+---
+description: "Pub/Sub transport: Google Cloud Pub/Sub configuration, Workload Identity, subscription setup"
+---
+
 # Pub/Sub
 
 Google Cloud Pub/Sub managed messaging service for actor communication.

--- a/docs/reference/transports/rabbitmq.md
+++ b/docs/reference/transports/rabbitmq.md
@@ -1,3 +1,7 @@
+---
+description: "RabbitMQ transport: connection config, exchange setup, prefetch, no delayed retry support"
+---
+
 # RabbitMQ
 
 Self-hosted open-source message broker.

--- a/docs/reference/transports/socket.md
+++ b/docs/reference/transports/socket.md
@@ -1,3 +1,7 @@
+---
+description: "Socket transport: Unix socket for local development, no infrastructure dependencies"
+---
+
 # Socket
 
 ⚠️ **Local testing only.** The socket transport exists exclusively for Docker Compose developer

--- a/docs/reference/transports/sqs.md
+++ b/docs/reference/transports/sqs.md
@@ -1,3 +1,7 @@
+---
+description: "SQS transport: AWS SQS configuration, IRSA/Pod Identity, queue auto-creation, retry with delay"
+---
+
 # SQS
 
 AWS-managed message queue service.

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,3 +1,7 @@
+---
+description: "Setup index: quickstart, cloud deployment (EKS/GKE), Helm charts, autoscaling, observability, ops"
+---
+
 # Run Asya
 
 Deploy Asya on your cluster, configure transports, monitor and scale.

--- a/docs/setup/guide-actor-flavors.md
+++ b/docs/setup/guide-actor-flavors.md
@@ -1,3 +1,7 @@
+---
+description: "Actor flavors setup: create EnvironmentConfig resources, GPU/CPU profiles, org-wide defaults"
+---
+
 # Actor Flavors
 
 This guide covers actor flavors from the platform engineer's perspective — how to create, configure, and manage reusable infrastructure presets for actors.

--- a/docs/setup/guide-autoscaling.md
+++ b/docs/setup/guide-autoscaling.md
@@ -1,3 +1,6 @@
+---
+description: "Autoscaling setup: KEDA configuration, ScaledObject parameters, scaling scenarios, GPU pods"
+---
 
 # Autoscaling
 

--- a/docs/setup/guide-error-handling.md
+++ b/docs/setup/guide-error-handling.md
@@ -1,3 +1,6 @@
+---
+description: "Error handling setup: configure resiliency policies, retry rules, DLQ routing in Helm values"
+---
 
 # Configuring Error Handling and Retries
 

--- a/docs/setup/guide-gateway.md
+++ b/docs/setup/guide-gateway.md
@@ -1,3 +1,7 @@
+---
+description: "Gateway setup: deploy api/mesh modes, configure auth, PostgreSQL, register MCP tools, A2A agents"
+---
+
 # Gateway
 
 This guide shows how to deploy and configure the Asya gateway, including authentication, tool registration, and multi-mode deployment.

--- a/docs/setup/guide-helm-charts.md
+++ b/docs/setup/guide-helm-charts.md
@@ -1,3 +1,7 @@
+---
+description: "Helm charts config: gateway, crew, crossplane chart values, image tags, resource limits"
+---
+
 # Helm Charts
 
 Asya🎭 provides Helm charts for deploying framework components.

--- a/docs/setup/guide-pause-resume.md
+++ b/docs/setup/guide-pause-resume.md
@@ -1,3 +1,7 @@
+---
+description: "Pause/resume setup: deploy x-pause/x-resume crew actors, configure S3 checkpoint bucket"
+---
+
 # Pause/Resume
 
 This guide shows how to deploy and configure the pause/resume infrastructure for human-in-the-loop workflows.

--- a/docs/setup/guide-state-proxy.md
+++ b/docs/setup/guide-state-proxy.md
@@ -1,3 +1,7 @@
+---
+description: "State proxy setup: configure storage backends (S3/GCS/Redis/NATS), Helm values, credentials"
+---
+
 # State Proxy
 
 This guide covers state proxy configuration at the infrastructure level — how to enable persistent state for actors, configure storage backends, and manage credentials.

--- a/docs/setup/guide-timeouts.md
+++ b/docs/setup/guide-timeouts.md
@@ -1,3 +1,7 @@
+---
+description: "Timeout setup: configure SLA deadline, actorTimeout, gateway backstop, transport visibility"
+---
+
 # Timeouts
 
 This guide covers timeout configuration at the platform level — how to set up timeout constraints in AsyncActor manifests, gateway configuration, and transport settings.

--- a/docs/setup/ops-observability.md
+++ b/docs/setup/ops-observability.md
@@ -1,3 +1,7 @@
+---
+description: "Observability ops: Prometheus metrics, Grafana dashboards, alerting rules, OpenTelemetry setup"
+---
+
 # Observability
 
 This guide shows how to set up monitoring for Asya deployments using Prometheus and Grafana.

--- a/docs/setup/ops-troubleshooting.md
+++ b/docs/setup/ops-troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: "Troubleshooting: symptom-to-solution checklist, common errors, debugging commands"
+---
+
 # Troubleshooting
 
 Common issues and solutions.

--- a/docs/setup/ops-upgrades.md
+++ b/docs/setup/ops-upgrades.md
@@ -1,3 +1,7 @@
+---
+description: "Upgrades: version upgrade procedures, Helm rollback, CRD migration, breaking changes"
+---
+
 # Upgrades
 
 Version upgrade procedures for Asya🎭 components.

--- a/docs/setup/start-actor-xrd.md
+++ b/docs/setup/start-actor-xrd.md
@@ -1,3 +1,7 @@
+---
+description: "Actor XRD deployment: deploy actors using Crossplane AsyncActor composite resource"
+---
+
 # Understanding the AsyncActor CRD
 
 The AsyncActor is the only CRD you need to deploy an actor on Kubernetes.

--- a/docs/setup/start-aws-eks.md
+++ b/docs/setup/start-aws-eks.md
@@ -1,3 +1,7 @@
+---
+description: "AWS EKS deployment: production setup, IRSA, SQS transport, S3 storage, KEDA on EKS"
+---
+
 # AWS EKS Installation
 
 Production deployment on Amazon EKS.

--- a/docs/setup/start-gcp-gke.md
+++ b/docs/setup/start-gcp-gke.md
@@ -1,3 +1,7 @@
+---
+description: "GCP GKE deployment: production setup, Workload Identity, Pub/Sub transport, GCS storage"
+---
+
 # GKE + GCP Pub/Sub Installation
 
 Deploy Asya on Google Kubernetes Engine using native GCP Pub/Sub as the message transport.

--- a/docs/setup/start-quickstart.md
+++ b/docs/setup/start-quickstart.md
@@ -1,3 +1,7 @@
+---
+description: "Quickstart: local Kind cluster setup, install Asya, deploy first actor in 5 minutes"
+---
+
 # Quickstart (Kind)
 
 Asya is an Actor Mesh framework for running AI/ML workloads on Kubernetes. Actors communicate

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,3 +1,7 @@
+---
+description: "Usage index: first actor, first mesh, first flow, handler patterns, agentic patterns, debugging"
+---
+
 # Build AI Actors 🎭
 
 Write Python functions, deploy as Kubernetes actors, chain into meshes.

--- a/docs/usage/guide-actor-flavors.md
+++ b/docs/usage/guide-actor-flavors.md
@@ -1,3 +1,7 @@
+---
+description: "Actor flavors usage: choose GPU/CPU profiles, reference flavors in AsyncActor spec"
+---
+
 # Actor Flavors
 
 Flavors are named, reusable building blocks that platform engineers pre-create

--- a/docs/usage/guide-actor-xrd.md
+++ b/docs/usage/guide-actor-xrd.md
@@ -1,3 +1,7 @@
+---
+description: "AsyncActor spec guide: write actor manifests, compositionSelector, inline config, XRD fields"
+---
+
 # AsyncActor Spec
 
 The AsyncActor is the only CRD you need to deploy an actor on Kubernetes.

--- a/docs/usage/guide-agentic-patterns.md
+++ b/docs/usage/guide-agentic-patterns.md
@@ -1,3 +1,6 @@
+---
+description: "Agentic patterns: fan-out, dynamic routing, conditional branching, LLM streaming, agent swarms"
+---
 
 # Agentic Patterns
 

--- a/docs/usage/guide-compiler-rules.md
+++ b/docs/usage/guide-compiler-rules.md
@@ -1,3 +1,7 @@
+---
+description: "Compiler rules usage: extend compiler with custom rules for decorators, context managers, calls"
+---
+
 # Compiler Rules
 
 How to use and extend the compiler's extensible rule system — the knowledge base

--- a/docs/usage/guide-error-handling.md
+++ b/docs/usage/guide-error-handling.md
@@ -1,3 +1,6 @@
+---
+description: "Error handling usage: try/except in flows, error routing patterns, finally blocks"
+---
 
 # Error Handling in Flows
 

--- a/docs/usage/guide-handler-patterns.md
+++ b/docs/usage/guide-handler-patterns.md
@@ -1,3 +1,7 @@
+---
+description: "Handler patterns: adapter pattern, generator vs function handlers, typed outputs, yield protocol"
+---
+
 # Handler Patterns
 
 This guide covers practical patterns for writing Asya actor handlers: from basic

--- a/docs/usage/guide-pause-resume.md
+++ b/docs/usage/guide-pause-resume.md
@@ -1,3 +1,6 @@
+---
+description: "Pause/resume usage: yield SET to x-pause, handle resume input, human-in-the-loop workflow"
+---
 
 # Pause/Resume
 

--- a/docs/usage/guide-state-proxy.md
+++ b/docs/usage/guide-state-proxy.md
@@ -1,3 +1,7 @@
+---
+description: "State proxy usage: read/write /state/ paths in Python handlers, file I/O interception"
+---
+
 # State Proxy
 
 How to read and write persistent state from your actor handlers using standard Python file operations.

--- a/docs/usage/guide-streaming.md
+++ b/docs/usage/guide-streaming.md
@@ -1,3 +1,7 @@
+---
+description: "Streaming guide: FLY events, SSE to gateway, live progress, partial token delivery"
+---
+
 # Streaming
 
 How to stream live progress updates from your actor handlers to gateway clients in real-time.

--- a/docs/usage/guide-timeouts.md
+++ b/docs/usage/guide-timeouts.md
@@ -1,3 +1,7 @@
+---
+description: "Timeout patterns: set actorTimeout, understand deadline behavior, SLA vs actor timeout"
+---
+
 # Timeouts
 
 How to configure per-actor timeouts in your AsyncActor specs to prevent runaway executions.

--- a/docs/usage/ops-debugging.md
+++ b/docs/usage/ops-debugging.md
@@ -1,3 +1,6 @@
+---
+description: "Debugging: trace envelopes by trace_id, curl the runtime, inspect x-sink/x-sump queues"
+---
 
 # Debugging
 

--- a/docs/usage/start-first-actor-mesh.md
+++ b/docs/usage/start-first-actor-mesh.md
@@ -1,3 +1,6 @@
+---
+description: "Tutorial: chain two actors via route.next, trace the envelope at each hop, verify pipeline"
+---
 
 # First Actor Mesh
 

--- a/docs/usage/start-first-actor.md
+++ b/docs/usage/start-first-actor.md
@@ -1,3 +1,6 @@
+---
+description: "Tutorial: build an echo actor, deploy to Kubernetes, send a message, verify the result"
+---
 
 # First Actor
 

--- a/docs/usage/start-first-flow.md
+++ b/docs/usage/start-first-flow.md
@@ -1,3 +1,6 @@
+---
+description: "Tutorial: write a Flow DSL file, compile to actor graph, inspect generated routers, deploy"
+---
 
 # First Flow
 

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Quickstart (Kind): setup/start-quickstart.md
     - AWS EKS: setup/start-aws-eks.md
     - GCP GKE: setup/start-gcp-gke.md
+    - Actor XRD (Crossplane): setup/start-actor-xrd.md
   - guides:
     - Helm Charts: setup/guide-helm-charts.md
     - Autoscaling: setup/guide-autoscaling.md
@@ -59,7 +60,7 @@ nav:
     - State Proxy: setup/guide-state-proxy.md
     - Pause/Resume: setup/guide-pause-resume.md
     - Timeouts: setup/guide-timeouts.md
-    - Retries: setup/guide-retries.md
+    - Error Handling: setup/guide-error-handling.md
     - Gateway: setup/guide-gateway.md
   - operations:
     - Observability: setup/ops-observability.md
@@ -80,6 +81,8 @@ nav:
     - State Proxy: usage/guide-state-proxy.md
     - Pause/Resume: usage/guide-pause-resume.md
     - Timeouts: usage/guide-timeouts.md
+    - Error Handling: usage/guide-error-handling.md
+    - Compiler Rules: usage/guide-compiler-rules.md
   - operations:
     - Debugging: usage/ops-debugging.md
 - reference:
@@ -104,6 +107,8 @@ nav:
     - Gateway API: reference/specs/gateway-api.md
     - Flow DSL: reference/specs/flow-dsl.md
     - Error Handling: reference/specs/error-handling.md
+    - Streaming Events: reference/specs/streaming-events.md
+    - Compiler Rules: reference/specs/compiler-rules.md
   - transports:
     - Overview: reference/transports/README.md
     - SQS: reference/transports/sqs.md
@@ -116,6 +121,9 @@ nav:
     - GCS: reference/state-proxy-connectors/gcs.md
     - Redis: reference/state-proxy-connectors/redis.md
     - NATS KV: reference/state-proxy-connectors/nats-kv.md
+  - scalers:
+    - Pub/Sub Scaler: reference/scalers/pubsub.md
+  - Credentials: reference/credentials.md
   - Environment Variables: reference/env-vars.md
 - Comparisons:
   - Overview: comparisons/README.md
@@ -135,6 +143,11 @@ nav:
     - vs KAgent: comparisons/vs-kagent.md
     - vs Ray Serve: comparisons/vs-ray-serve.md
     - vs Kubeflow Pipelines: comparisons/vs-kubeflow-pipelines.md
+- Contributing:
+  - Overview: contributing/README.md
+  - Testing Transport: contributing/testing-transport.md
+  - Testing State Proxy: contributing/testing-state-proxy.md
+  - Testing A2A: contributing/testing-a2a.md
 plugins:
 - shadcn/search:
     prebuild_index: python


### PR DESCRIPTION
## Summary

- Add YAML frontmatter `description` to all 103 markdown files in `docs/` — grep-friendly one-liners with searchable keywords so coding agents can quickly find the right documentation
- Add "Documentation Discovery" section to `AGENTS.md` with search commands, section overview, and naming conventions
- Fix `mkdocs.yml` nav consistency: replace phantom `setup/guide-retries.md`, add 9 missing pages, add Contributing section

## Details

**Frontmatter format** (added to every doc):
```yaml
---
description: "ABI protocol: yield-based commands (GET/SET/DEL/FLY), path syntax, access control, type dispatch"
---
```

**Agent discovery** (new section in AGENTS.md):
```bash
grep -r "description:.*routing" docs/ --include="*.md" -l
grep -r "description:.*sidecar" docs/ --include="*.md" -l
```

**mkdocs.yml fixes**:
- `setup/guide-retries.md` → `setup/guide-error-handling.md` (file didn't exist)
- Added to nav: `contributing/*`, `reference/credentials.md`, `reference/scalers/pubsub.md`, `reference/specs/streaming-events.md`, `reference/specs/compiler-rules.md`, `setup/start-actor-xrd.md`, `usage/guide-error-handling.md`, `usage/guide-compiler-rules.md`
- Added Contributing section (was entirely missing from nav)
- Result: 100% parity between mkdocs nav entries and files on disk

## Test plan

- [x] All 103 docs have exactly one frontmatter block (verified: `grep -c "^---" | head -5` per file)
- [x] `diff <(nav entries) <(files on disk)` produces empty output (100% parity)
- [x] Pre-commit hooks pass (yamlfmt, yamllint, etc.)
- [ ] Verify mkdocs site builds (`cd docs/website && mkdocs build`)