### PR TITLE
fix(lint): Fix lint

### DIFF
--- a/src/asya-testing/tests/test_gateway_helper.py
+++ b/src/asya-testing/tests/test_gateway_helper.py
@@ -3,10 +3,9 @@
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
-from urllib.parse import urlparse
+from typing import ClassVar
 
 import pytest
-
 from asya_testing.utils.gateway import GatewayTestHelper
 
 
@@ -14,7 +13,7 @@ class FakeMCPHandler(BaseHTTPRequestHandler):
     """Minimal MCP adapter stub: handles initialize + tools/call."""
 
     task_id = "test-task-abc123"
-    recorded_requests: list = []
+    recorded_requests: ClassVar[list] = []
     SESSION_ID = "test-session-001"
 
     def do_POST(self):  # noqa: N802
@@ -118,9 +117,15 @@ def test_call_mcp_tool_no_task_id_raises(fake_mcp_server):
                 self.send_header("Mcp-Session-Id", "no-meta-session")
             self.end_headers()
             if req.get("method") == "initialize":
-                response = {"jsonrpc": "2.0", "id": req["id"], "result": {
-                    "protocolVersion": "2025-03-26", "capabilities": {}, "serverInfo": {"name": "x", "version": "1"}
-                }}
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": req["id"],
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "x", "version": "1"},
+                    },
+                }
             else:
                 response = {
                     "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
- Upgrade system Go from 1.24 to 1.25.9 to match `go.mod` requirements
- Rebuild golangci-lint with Go 1.25.9 (was incompatible with go1.24)
- Fix ruff linting error: annotate mutable class attribute with `typing.ClassVar`
- Remove unused import and apply formatter changes

## Test plan
- [x] `make lint` passes all hooks (ruff, mypy, golangci-lint, etc.)
- [x] All linters pass on modified file
- [x] Commit includes DCO sign-off