### PR TITLE
feat(crossplane): add initContainers and sidecars to AsyncActor XRD [cynl0]

### DIFF
--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -570,10 +570,10 @@ spec:
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -569,6 +569,12 @@ spec:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.initContainers | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.sidecars | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir
                           emptyDir: {}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -397,6 +397,12 @@ spec:
                           asya.sh/actor: {{`{{ $actorName }}`}}
                       spec:
                         terminationGracePeriodSeconds: 30
+                        {{`{{- if $xrSpec.initContainers }}`}}
+                        initContainers:
+                        {{`{{- range $xrSpec.initContainers }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- end }}`}}
                         containers:
                         - name: asya-runtime
                           image: {{`{{ $xrSpec.image | quote }}`}}
@@ -568,9 +574,6 @@ spec:
                           volumeMounts:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
-                        {{`{{- end }}`}}
-                        {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
                         - {{`{{ . | toYaml | nindent 14 }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -469,6 +469,12 @@ spec:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.initContainers | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.sidecars | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir
                           emptyDir: {}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -301,6 +301,12 @@ spec:
                           asya.sh/actor: {{`{{ $actorName }}`}}
                       spec:
                         terminationGracePeriodSeconds: 30
+                        {{`{{- if $xrSpec.initContainers }}`}}
+                        initContainers:
+                        {{`{{- range $xrSpec.initContainers }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- end }}`}}
                         containers:
                         - name: asya-runtime
                           image: {{`{{ $xrSpec.image | quote }}`}}
@@ -468,9 +474,6 @@ spec:
                           volumeMounts:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
-                        {{`{{- end }}`}}
-                        {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
                         - {{`{{ . | toYaml | nindent 14 }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -470,10 +470,10 @@ spec:
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -425,6 +425,12 @@ spec:
                         {{- if .Values.irsa.enabled }}
                         serviceAccountName: {{ .Values.irsa.serviceAccountName }}
                         {{- end }}
+                        {{`{{- if $xrSpec.initContainers }}`}}
+                        initContainers:
+                        {{`{{- range $xrSpec.initContainers }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- end }}`}}
                         containers:
                         - name: asya-runtime
                           image: {{`{{ $xrSpec.image | quote }}`}}
@@ -605,9 +611,6 @@ spec:
                           volumeMounts:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
-                        {{`{{- end }}`}}
-                        {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
                         - {{`{{ . | toYaml | nindent 14 }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -607,10 +607,10 @@ spec:
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.initContainers | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         {{`{{- range $xrSpec.sidecars | default list }}`}}
-                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        - {{`{{ . | toYaml | nindent 14 }}`}}
                         {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -606,6 +606,12 @@ spec:
                           - name: state-sockets
                             mountPath: /var/run/asya/state
                         {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.initContainers | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
+                        {{`{{- range $xrSpec.sidecars | default list }}`}}
+                        - {{`{{ . | toYaml | nindent 12 }}`}}
+                        {{`{{- end }}`}}
                         volumes:
                         - name: socket-dir
                           emptyDir: {}

--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -145,7 +145,7 @@ spec:
 
                 sidecars:
                   type: array
-                  description: Additional sidecar containers for the actor pod
+                  description: "Additional sidecar containers for the actor pod (names 'asya-runtime' and 'asya-sidecar' are reserved)"
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -136,6 +136,20 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
 
+                initContainers:
+                  type: array
+                  description: Init containers to run before the asya-runtime container starts
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+
+                sidecars:
+                  type: array
+                  description: Additional sidecar containers for the actor pod
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+
                 scaling:
                   type: object
                   description: KEDA autoscaling configuration

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2197,7 +2197,7 @@ spec:
         cpu: "10m"
       limits:
         memory: "32Mi"
-        cpu: "50m\""""
+        cpu: 50m"""
 
     try:
         logger.info("Creating AsyncActor with sidecars...")

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2082,7 +2082,7 @@ def test_asyncactor_infrastructure_keda_ready_updates(e2e_helper):
 
 
 # ---------------------------------------------------------------------------
-# New tests: initContainers and sidecars (cynl0)
+# Tests: initContainers and sidecars
 # ---------------------------------------------------------------------------
 
 
@@ -2091,7 +2091,7 @@ def test_init_containers_rendered(e2e_helper):
     E2E: Test initContainers are rendered into the pod spec.
 
     Scenario:
-    1. Create AsyncActor with initContainers spec (alpine:latest as a no-op init)
+    1. Create AsyncActor with initContainers spec (no-op init)
     2. Verify Pod has init containers in addition to runtime + sidecar
 
     Expected: initContainers section present in the rendered Pod spec
@@ -2112,11 +2112,9 @@ spec:
   handler: asya_testing.handlers.payload.echo_handler
   initContainers:
   - name: init-setup
-    image: alpine:3.20
-    command: ["sh", "-c", "echo initializing && sleep 1"]
-    volumeMounts:
-    - name: tmp
-      mountPath: /tmp"""
+    image: ghcr.io/deliveryhero/asya-testing:latest
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "echo initializing"]"""
 
     try:
         logger.info("Creating AsyncActor with initContainers...")
@@ -2168,7 +2166,7 @@ def test_sidecar_containers_rendered(e2e_helper):
     E2E: Test custom sidecar containers are rendered alongside asya-sidecar.
 
     Scenario:
-    1. Create AsyncActor with sidecars spec (busybox as a test sidecar)
+    1. Create AsyncActor with sidecars spec
     2. Verify Pod has 3 containers (runtime + sidecar + custom sidecar)
 
     Expected: Custom sidecar rendered alongside asya-sidecar
@@ -2189,15 +2187,9 @@ spec:
   handler: asya_testing.handlers.payload.echo_handler
   sidecars:
   - name: test-sidecar
-    image: busybox:1.37
-    command: ["sh", "-c", "echo running sidecar && sleep 3600"]
-    resources:
-      requests:
-        memory: "16Mi"
-        cpu: "10m"
-      limits:
-        memory: "32Mi"
-        cpu: 50m"""
+    image: ghcr.io/deliveryhero/asya-testing:latest
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "sleep 3600"]"""
 
     try:
         logger.info("Creating AsyncActor with sidecars...")

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2079,3 +2079,154 @@ def test_asyncactor_infrastructure_keda_ready_updates(e2e_helper):
         raise
     finally:
         _cleanup_actor(name, e2e_helper.namespace)
+
+
+# ---------------------------------------------------------------------------
+# New tests: initContainers and sidecars (cynl0)
+# ---------------------------------------------------------------------------
+
+
+def test_init_containers_rendered(e2e_helper):
+    """
+    E2E: Test initContainers are rendered into the pod spec.
+
+    Scenario:
+    1. Create AsyncActor with initContainers spec (alpine:latest as a no-op init)
+    2. Verify Pod has init containers in addition to runtime + sidecar
+
+    Expected: initContainers section present in the rendered Pod spec
+    """
+    name = "test-init-containers"
+    manifest = f"""\
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: {name}
+  namespace: {e2e_helper.namespace}
+spec:
+  actor: {name}
+  scaling:
+    enabled: false
+  image: ghcr.io/deliveryhero/asya-testing:latest
+  imagePullPolicy: IfNotPresent
+  handler: asya_testing.handlers.payload.echo_handler
+  initContainers:
+  - name: init-setup
+    image: alpine:3.20
+    command: ["sh", "-c", "echo initializing && sleep 1"]
+    volumeMounts:
+    - name: tmp
+      mountPath: /tmp"""
+
+    try:
+        logger.info("Creating AsyncActor with initContainers...")
+        kubectl_apply(manifest, namespace=e2e_helper.namespace)
+
+        logger.info("Waiting for AsyncActor to be ready...")
+        assert wait_for_asyncactor_ready(name, namespace=e2e_helper.namespace, timeout=300), (
+            "AsyncActor should reach Ready"
+        )
+
+        logger.info("Checking Pod init containers...")
+        result = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                e2e_helper.namespace,
+                "-l",
+                f"asya.sh/actor={name}",
+                "-o",
+                "jsonpath={.items[0].spec.initContainers}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.stdout.strip(), "Pod should have initContainers"
+
+        init_containers_spec = json.loads(result.stdout)
+        init_names = [c["name"] for c in init_containers_spec]
+        logger.info(f"Pod initContainers: {init_names}")
+
+        assert "init-setup" in init_names, (
+            f"init-setup init container should be present, got: {init_names}"
+        )
+
+        logger.info("[+] initContainers rendering verified")
+
+    except Exception:
+        log_asyncactor_workload_diagnostics(name, namespace=e2e_helper.namespace)
+        raise
+    finally:
+        _cleanup_actor(name, e2e_helper.namespace)
+
+
+def test_sidecar_containers_rendered(e2e_helper):
+    """
+    E2E: Test custom sidecar containers are rendered alongside asya-sidecar.
+
+    Scenario:
+    1. Create AsyncActor with sidecars spec (busybox as a test sidecar)
+    2. Verify Pod has 3 containers (runtime + sidecar + custom sidecar)
+
+    Expected: Custom sidecar rendered alongside asya-sidecar
+    """
+    name = "test-sidecars"
+    manifest = f"""\
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: {name}
+  namespace: {e2e_helper.namespace}
+spec:
+  actor: {name}
+  scaling:
+    enabled: false
+  image: ghcr.io/deliveryhero/asya-testing:latest
+  imagePullPolicy: IfNotPresent
+  handler: asya_testing.handlers.payload.echo_handler
+  sidecars:
+  - name: test-sidecar
+    image: busybox:1.37
+    command: ["sh", "-c", "echo running sidecar && sleep 3600"]
+    resources:
+      requests:
+        memory: "16Mi"
+        cpu: "10m"
+      limits:
+        memory: "32Mi"
+        cpu: "50m\""""
+
+    try:
+        logger.info("Creating AsyncActor with sidecars...")
+        kubectl_apply(manifest, namespace=e2e_helper.namespace)
+
+        logger.info("Waiting for AsyncActor to be ready...")
+        assert wait_for_asyncactor_ready(name, namespace=e2e_helper.namespace, timeout=300), (
+            "AsyncActor should reach Ready"
+        )
+
+        logger.info("Checking Pod containers...")
+        containers = _get_pod_containers(name, e2e_helper.namespace)
+        container_names = [c["name"] for c in containers]
+        logger.info(f"Pod containers: {container_names}")
+
+        assert len(containers) == 3, (
+            f"Pod should have 3 containers (runtime + sidecar + test-sidecar), "
+            f"got {len(containers)}: {container_names}"
+        )
+        assert "asya-sidecar" in container_names, "Sidecar should be present"
+        assert "asya-runtime" in container_names, "Runtime container should exist"
+        assert "test-sidecar" in container_names, (
+            f"test-sidecar should be present, got: {container_names}"
+        )
+
+        logger.info("[+] Custom sidecars rendering verified")
+
+    except Exception:
+        log_asyncactor_workload_diagnostics(name, namespace=e2e_helper.namespace)
+        raise
+    finally:
+        _cleanup_actor(name, e2e_helper.namespace)

--- a/testing/e2e/tests/test_crossplane_keda.py
+++ b/testing/e2e/tests/test_crossplane_keda.py
@@ -506,3 +506,81 @@ class TestScaledObjectWatchEnabled:
             "ScaledObject Object resource must have watch: true so provider-kubernetes "
             "observes status changes and populates status.atProvider.manifest.status"
         )
+
+
+class TestInitContainersAndSidecarsXrdSchema:
+    """Test XRD schema for spec.initContainers and spec.sidecars fields."""
+
+    @pytest.fixture
+    def spec_schema(self) -> dict:
+        docs = helm_template()
+        xrd = find_xrd(docs, "xasyncactors.asya.sh")
+        assert xrd is not None
+        versions = xrd["spec"]["versions"]
+        v1alpha1 = next(v for v in versions if v["name"] == "v1alpha1")
+        return v1alpha1["schema"]["openAPIV3Schema"]["properties"]["spec"]
+
+    def test_init_containers_field_exists(self, spec_schema):
+        """Test that initContainers is defined in the XRD schema."""
+        assert "initContainers" in spec_schema["properties"]
+
+    def test_init_containers_is_opaque_array(self, spec_schema):
+        """Test that initContainers is an array of opaque objects."""
+        field = spec_schema["properties"]["initContainers"]
+        assert field["type"] == "array"
+        assert field["items"]["type"] == "object"
+        assert field["items"].get("x-kubernetes-preserve-unknown-fields") is True
+
+    def test_sidecars_field_exists(self, spec_schema):
+        """Test that sidecars is defined in the XRD schema."""
+        assert "sidecars" in spec_schema["properties"]
+
+    def test_sidecars_is_opaque_array(self, spec_schema):
+        """Test that sidecars is an array of opaque objects."""
+        field = spec_schema["properties"]["sidecars"]
+        assert field["type"] == "array"
+        assert field["items"]["type"] == "object"
+        assert field["items"].get("x-kubernetes-preserve-unknown-fields") is True
+
+
+class TestInitContainersAndSidecarsCompositionTemplates:
+    """Test compositions render initContainers and sidecars in the correct pod spec location.
+
+    Regression: initContainers must be rendered as spec.initContainers (sibling of
+    spec.containers), not as items inside the containers list.
+    """
+
+    @pytest.fixture(params=["asyncactor-sqs", "asyncactor-rabbitmq"])
+    def deployment_template(self, request) -> str:
+        """Get the render-deployment Go template from each composition."""
+        docs = helm_template()
+        comp = find_composition(docs, request.param)
+        assert comp is not None, f"{request.param} Composition should exist"
+        step = get_pipeline_step(comp, "render-deployment")
+        return step["input"]["inline"]["template"]
+
+    def test_init_containers_has_own_key(self, deployment_template):
+        """Test initContainers is rendered as a pod spec key, not inside containers."""
+        assert "initContainers:" in deployment_template
+
+    def test_init_containers_is_conditional(self, deployment_template):
+        """Test initContainers rendering is gated on the field being set."""
+        assert "if $xrSpec.initContainers" in deployment_template
+
+    def test_init_containers_not_inside_containers_list(self, deployment_template):
+        """Regression: initContainers range must not appear between containers: and volumes:."""
+        containers_pos = deployment_template.index("containers:")
+        volumes_pos = deployment_template.index("volumes:")
+        containers_section = deployment_template[containers_pos:volumes_pos]
+        assert "range $xrSpec.initContainers" not in containers_section, (
+            "initContainers should be rendered as spec.initContainers, "
+            "not as items inside the spec.containers list"
+        )
+
+    def test_sidecars_rendered_inside_containers(self, deployment_template):
+        """Test sidecars are additional items in the containers list."""
+        assert "range $xrSpec.sidecars" in deployment_template
+        containers_pos = deployment_template.index("containers:")
+        volumes_pos = deployment_template.index("volumes:")
+        containers_section = deployment_template[containers_pos:volumes_pos]
+        assert "range $xrSpec.sidecars" in containers_section


### PR DESCRIPTION
## Summary

Extend the AsyncActor XRD with `initContainers` and `sidecars` fields using `x-kubernetes-preserve-unknown-fields: true` for full container spec flexibility. Update all three transport compositions (SQS, RabbitMQ, PubSub) to render these into the pod spec alongside the asya-sidecar and state proxy containers.

**Why:** Enables code delivery to training actors via init containers (git-sync, pip-install) without building custom Docker images — a Tier-1 requirement for the autoresearch feature.

## Changes

- **XRD** (`xrd-asyncactor.yaml`): Added `initContainers` and `sidecars` array fields with `x-kubernetes-preserve-unknown-fields: true`
- **Compositions** (`composition-sqs.yaml`, `composition-rabbitmq.yaml`, `composition-pubsub.yaml`): Render init containers and sidecars into the pod spec using `$xrSpec.initContainers | default list` and `$xrSpec.sidecars | default list`
- **E2E tests** (`test_crossplane_e2e.py`): Added `test_init_containers_rendered` and `test_sidecar_containers_rendered`

## Test plan

- [ ] `helm template` renders initContainers/sidecars correctly for all 3 transports
- [ ] E2E: deploy actor with initContainers spec, verify Pod has init containers
- [ ] E2E: deploy actor with sidecars spec, verify Pod has 3 containers (runtime + sidecar + custom)
- [ ] `make test-e2e` with `PYTEST_OPTS="-vv -k 'test_init_containers or test_sidecar' -p no:xdist"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)