### PR TITLE
ci: fix changelog automation and skip bot checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -71,18 +71,10 @@ jobs:
 
         mv "$TEMP_FILE" CHANGELOG.md
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v8
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Update CHANGELOG.md for ${{ steps.release.outputs.tag }}"
-        title: "Update CHANGELOG.md for ${{ steps.release.outputs.tag }}"
-        body: |
-          Automated changelog update for release ${{ steps.release.outputs.tag }}.
-
-          This PR was automatically created by the changelog workflow.
-        branch: changelog-${{ steps.release.outputs.tag }}
-        delete-branch: true
-        labels: |
-          documentation
-          automated
+    - name: Commit and push CHANGELOG.md
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add CHANGELOG.md
+        git diff --cached --quiet || git commit -m "chore: Update CHANGELOG.md for ${{ steps.release.outputs.tag }}"
+        git push

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,6 +11,7 @@ jobs:
   dco-check:
     name: DCO Sign-off
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
 
     steps:
     - name: Check DCO sign-off

--- a/.github/workflows/pr-commit.yml
+++ b/.github/workflows/pr-commit.yml
@@ -12,6 +12,7 @@ jobs:
   validate-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
 
     steps:
     - name: Check for Semantic Title

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,38 +118,6 @@ jobs:
         EOF
         fi
 
-  reserve-image-names:
-    name: Reserve placeholder image names
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        name:
-        - asya-magic
-        - asya-sdk
-        - asya-workbench
-        - asya-dashboard
-        - asya-webhook
-        - function-asya-flavors
-
-    steps:
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Reserve image name
-      run: |
-        IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}"
-        echo "[.] Reserving ${IMAGE_NAME}:reserved"
-        docker pull alpine:3.20
-        docker tag alpine:3.20 "${IMAGE_NAME}:reserved"
-        docker push "${IMAGE_NAME}:reserved"
-        echo "[+] Reserved ${IMAGE_NAME}:reserved"
-
   publish-helm-charts:
     name: Publish Helm charts
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **`changelog.yml`**: replace `peter-evans/create-pull-request` with a direct `git commit && git push` to `main` — eliminates the need for manual approval, bypasses DCO enforcement, and avoids the semantic PR title rejection that broke the v1.1.0 changelog update
- **`dco.yml`** + **`pr-commit.yml`**: skip both checks when `github.actor` is `github-actions[bot]` or `dependabot[bot]` — bots cannot add `Signed-off-by` trailers or follow conventional commits format
- **`release.yml`**: remove `reserve-image-names` job (no longer needed)

## Test plan

- [ ] Publish a new release and verify changelog commits directly to `main` without creating a PR
- [ ] Verify Dependabot PRs are no longer blocked by DCO or semantic title check