### PR TITLE
feat(state-proxy): consolidate images into asya-state-proxy-py and asya-state-proxy-go [okw15]

### DIFF
--- a/deploy/helm-charts/asya-crew/templates/_helpers.tpl
+++ b/deploy/helm-charts/asya-crew/templates/_helpers.tpl
@@ -237,11 +237,7 @@ If "bucket" key is absent, falls back to .Values.persistence.config.bucket.
 {{- $bucket := default $values.persistence.config.bucket .bucket }}
 {{- $connectorImage := dict "val" $values.persistence.connector.image }}
 {{- if not $connectorImage.val }}
-  {{- if eq $values.persistence.backend "s3" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-s3-buffered-lww:{{ $.Chart.AppVersion }}" }}
-  {{- else if eq $values.persistence.backend "gcs" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-gcs-buffered-lww:{{ $.Chart.AppVersion }}" }}
-  {{- end }}
+  {{- $_ := set $connectorImage "val" (printf "ghcr.io/deliveryhero/asya-state-proxy-py:%s" $.Chart.AppVersion) }}
 {{- end }}
 - name: checkpoints
   mount:
@@ -249,6 +245,8 @@ If "bucket" key is absent, falls back to .Values.persistence.config.bucket.
   connector:
     image: {{ $connectorImage.val }}
     env:
+      - name: ASYA_CONNECTOR
+        value: {{ if eq $values.persistence.backend "s3" }}s3_buffered_lww{{ else }}gcs_buffered_lww{{ end }}
       - name: STATE_BUCKET
         value: {{ $bucket | quote }}
       {{- if eq $values.persistence.backend "s3" }}

--- a/deploy/helm-charts/asya-crew/templates/persistence-flavor.yaml
+++ b/deploy/helm-charts/asya-crew/templates/persistence-flavor.yaml
@@ -7,11 +7,7 @@
 {{- end }}
 {{- $connectorImage := dict "val" .Values.persistence.connector.image }}
 {{- if not $connectorImage.val }}
-  {{- if eq .Values.persistence.backend "s3" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-s3-buffered-lww:{{ .Chart.AppVersion }}" }}
-  {{- else if eq .Values.persistence.backend "gcs" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-gcs-buffered-lww:{{ .Chart.AppVersion }}" }}
-  {{- end }}
+  {{- $_ := set $connectorImage "val" (printf "ghcr.io/deliveryhero/asya-state-proxy-py:%s" .Chart.AppVersion) }}
 {{- end }}
 apiVersion: apiextensions.crossplane.io/v1beta1
 kind: EnvironmentConfig
@@ -28,6 +24,8 @@ data:
       connector:
         image: {{ $connectorImage.val }}
         env:
+          - name: ASYA_CONNECTOR
+            value: {{ if eq .Values.persistence.backend "s3" }}s3_buffered_lww{{ else }}gcs_buffered_lww{{ end }}
           - name: STATE_BUCKET
             value: {{ .Values.persistence.config.bucket | quote }}
           {{- if eq .Values.persistence.backend "s3" }}

--- a/deploy/helm-charts/asya-gateway/templates/deployment.yaml
+++ b/deploy/helm-charts/asya-gateway/templates/deployment.yaml
@@ -261,6 +261,8 @@ spec:
         image: "{{ .Values.stateProxy.envelopes.image.repository }}:{{ .Values.stateProxy.envelopes.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.stateProxy.envelopes.image.pullPolicy }}
         env:
+        - name: ASYA_CONNECTOR
+          value: s3_buffered_lww
         - name: CONNECTOR_SOCKET
           value: {{ printf "%s/state-proxy.sock" .Values.stateProxy.envelopes.socketDir | quote }}
         - name: STATE_BUCKET

--- a/deploy/helm-charts/asya-gateway/values.yaml
+++ b/deploy/helm-charts/asya-gateway/values.yaml
@@ -56,7 +56,7 @@ a2a:
 stateProxy:
   mesh:
     image:
-      repository: ghcr.io/deliveryhero/asya-state-proxy-pg-kv
+      repository: ghcr.io/deliveryhero/asya-state-proxy-go
       tag: ""
       pullPolicy: IfNotPresent
     resources:
@@ -71,7 +71,7 @@ stateProxy:
   envelopes:
     enabled: false
     image:
-      repository: ghcr.io/deliveryhero/asya-state-proxy-s3-buffered-lww
+      repository: ghcr.io/deliveryhero/asya-state-proxy-py
       tag: ""
       pullPolicy: IfNotPresent
     resources:

--- a/docs/contributing/testing-state-proxy.md
+++ b/docs/contributing/testing-state-proxy.md
@@ -177,7 +177,7 @@ make -C testing/integration/gateway-actors test      # all profiles
 
 - The `x-sink` crew actor correctly persists the processed envelope to storage
   after routing through sidecar → runtime → x-sink sidecar → x-sink runtime
-- The connector image (built from `Dockerfile.gcs-buffered-lww`) loads and
+- The connector image (`asya-state-proxy-py` with `ASYA_CONNECTOR=gcs_buffered_lww`) loads and
   connects successfully inside a real container
 - Bucket existence is verified: tests assert the object appeared in the bucket
   using the emulator API
@@ -252,10 +252,10 @@ For E2E tests, connector images are built locally and loaded into Kind:
 
 ```bash
 # scripts/deploy.sh (pubsub-gcs profile)
-docker build -t asya-state-proxy-gcs-buffered-lww:dev \
-  -f src/asya-state-proxy/Dockerfile.gcs-buffered-lww \
+docker build -t asya-state-proxy-py:dev \
+  -f src/asya-state-proxy/Dockerfile \
   src/asya-state-proxy/
-kind load docker-image asya-state-proxy-gcs-buffered-lww:dev \
+kind load docker-image asya-state-proxy-py:dev \
   --name asya-e2e-pubsub-gcs
 ```
 

--- a/src/asya-state-proxy/Dockerfile
+++ b/src/asya-state-proxy/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.13-slim
 WORKDIR /app
 COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir ".[s3,gcs,redis]"
-ENTRYPOINT ["sh", "-c", "exec python -m asya_state_proxy.connectors.${ASYA_CONNECTOR}"]
+    pip install ".[s3,gcs,redis]"
+COPY asya_state_proxy/ asya_state_proxy/
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/asya-state-proxy/Dockerfile
+++ b/src/asya-state-proxy/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.13-slim
 WORKDIR /app
 COPY pyproject.toml .
+COPY asya_state_proxy/ asya_state_proxy/
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install ".[s3,gcs,redis]"
-COPY asya_state_proxy/ asya_state_proxy/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/asya-state-proxy/Dockerfile
+++ b/src/asya-state-proxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY pyproject.toml .
+COPY asya_state_proxy/ asya_state_proxy/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir ".[s3,gcs,redis]"
+ENTRYPOINT ["sh", "-c", "exec python -m asya_state_proxy.connectors.${ASYA_CONNECTOR}"]

--- a/src/asya-state-proxy/Dockerfile
+++ b/src/asya-state-proxy/Dockerfile
@@ -5,6 +5,8 @@ COPY asya_state_proxy/ asya_state_proxy/
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install ".[s3,gcs,redis]"
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh \
+    && mkdir -p /var/run/asya/state \
+    && chmod 777 /var/run/asya/state
 USER nobody
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/asya-state-proxy/Dockerfile
+++ b/src/asya-state-proxy/Dockerfile
@@ -6,4 +6,5 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install ".[s3,gcs,redis]"
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+USER nobody
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/asya-state-proxy/Dockerfile.gcs-buffered-cas
+++ b/src/asya-state-proxy/Dockerfile.gcs-buffered-cas
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[gcs]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.gcs_buffered_cas"]

--- a/src/asya-state-proxy/Dockerfile.gcs-buffered-lww
+++ b/src/asya-state-proxy/Dockerfile.gcs-buffered-lww
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[gcs]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.gcs_buffered_lww"]

--- a/src/asya-state-proxy/Dockerfile.go
+++ b/src/asya-state-proxy/Dockerfile.go
@@ -1,4 +1,5 @@
 FROM golang:1.25-alpine AS builder
+ENV GOTOOLCHAIN=local
 WORKDIR /app/go
 
 COPY go/go.mod go/go.sum ./

--- a/src/asya-state-proxy/Dockerfile.go
+++ b/src/asya-state-proxy/Dockerfile.go
@@ -1,20 +1,16 @@
 FROM golang:1.25-alpine AS builder
 WORKDIR /app/go
 
-# Copy go mod files and download dependencies
 COPY go/go.mod go/go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-# Copy source
 COPY go/ .
 
-# Build binary
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux go build -o /pg-kv ./cmd/pg-kv/
 
-# Runtime image
 FROM alpine:3.20
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /pg-kv /pg-kv

--- a/src/asya-state-proxy/Dockerfile.redis-buffered-cas
+++ b/src/asya-state-proxy/Dockerfile.redis-buffered-cas
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[redis]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.redis_buffered_cas"]

--- a/src/asya-state-proxy/Dockerfile.s3-buffered-cas
+++ b/src/asya-state-proxy/Dockerfile.s3-buffered-cas
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[s3]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.s3_buffered_cas"]

--- a/src/asya-state-proxy/Dockerfile.s3-buffered-lww
+++ b/src/asya-state-proxy/Dockerfile.s3-buffered-lww
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[s3]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.s3_buffered_lww"]

--- a/src/asya-state-proxy/Dockerfile.s3-passthrough
+++ b/src/asya-state-proxy/Dockerfile.s3-passthrough
@@ -1,6 +1,0 @@
-FROM python:3.13-slim
-WORKDIR /app
-COPY pyproject.toml .
-COPY asya_state_proxy/ asya_state_proxy/
-RUN pip install --no-cache-dir ".[s3]"
-ENTRYPOINT ["python", "-m", "asya_state_proxy.connectors.s3_passthrough"]

--- a/src/asya-state-proxy/entrypoint.sh
+++ b/src/asya-state-proxy/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+case "$ASYA_CONNECTOR" in
+  *[!a-zA-Z0-9_]* | "")
+    echo "[!] ASYA_CONNECTOR must be set to a valid connector name (alphanumeric + underscore)"
+    exit 1
+    ;;
+esac
+exec python -m "asya_state_proxy.connectors.${ASYA_CONNECTOR}"

--- a/src/build-images.sh
+++ b/src/build-images.sh
@@ -69,6 +69,8 @@ while [[ $# -gt 0 ]]; do
       echo "  - asya-lab"
       echo "  - asya-scalers"
       echo "  - asya-sidecar"
+      echo "  - asya-state-proxy-go"
+      echo "  - asya-state-proxy-py"
       echo "  - asya-testing"
       echo "  - asya-ui"
       echo "  - function-asya-flavors"
@@ -197,16 +199,29 @@ declare -a ALL_IMAGES=(
   "asya-lab"
   "asya-scalers"
   "asya-sidecar"
+  "asya-state-proxy-go"
+  "asya-state-proxy-py"
   "asya-testing"
   "asya-ui"
   "function-asya-flavors"
 )
 
 # Resolve build context for an image name.
-# Most images live at src/{name}/.
 get_build_context() {
   local name=$1
-  echo "src/$name"
+  case "$name" in
+    asya-state-proxy-go | asya-state-proxy-py) echo "src/asya-state-proxy" ;;
+    *) echo "src/$name" ;;
+  esac
+}
+
+# Resolve Dockerfile name for an image.
+get_dockerfile() {
+  local name=$1
+  case "$name" in
+    asya-state-proxy-go) echo "Dockerfile.go" ;;
+    *) echo "Dockerfile" ;;
+  esac
 }
 
 # Filter images if specific ones are requested
@@ -240,7 +255,8 @@ time {
     index=$((i + 1))
 
     context=$(get_build_context "$name")
-    build_image "$name" "$context" "Dockerfile" "$index" "$TOTAL_IMAGES" &
+    dockerfile=$(get_dockerfile "$name")
+    build_image "$name" "$context" "$dockerfile" "$index" "$TOTAL_IMAGES" &
 
     BUILD_PIDS+=($!)
   done

--- a/testing/component/mesh-api/profiles/sqs.yml
+++ b/testing/component/mesh-api/profiles/sqs.yml
@@ -68,7 +68,7 @@ services:
   pg-kv:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.pg-kv
+      dockerfile: Dockerfile.go
       target: builder
     logging: *default-logging
     command: ["go", "run", "./cmd/pg-kv/"]

--- a/testing/component/sidecar/profiles/rabbitmq.yml
+++ b/testing/component/sidecar/profiles/rabbitmq.yml
@@ -48,7 +48,7 @@ services:
   pg-kv:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.pg-kv
+      dockerfile: Dockerfile.go
       target: builder
     command: ["go", "run", "./cmd/pg-kv/"]
     environment:

--- a/testing/component/sidecar/profiles/sqs.yml
+++ b/testing/component/sidecar/profiles/sqs.yml
@@ -50,7 +50,7 @@ services:
   pg-kv:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.pg-kv
+      dockerfile: Dockerfile.go
       target: builder
     command: ["go", "run", "./cmd/pg-kv/"]
     environment:

--- a/testing/component/state-proxy/profiles/.env.gcs-cas
+++ b/testing/component/state-proxy/profiles/.env.gcs-cas
@@ -1,4 +1,5 @@
-CONNECTOR_DOCKERFILE=Dockerfile.gcs-buffered-cas
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=gcs_buffered_cas
 WRITE_MODE=buffered
 STATE_BUCKET=asya-state-test
 STORAGE_EMULATOR_HOST=http://fake-gcs:4443

--- a/testing/component/state-proxy/profiles/.env.gcs-lww
+++ b/testing/component/state-proxy/profiles/.env.gcs-lww
@@ -1,4 +1,5 @@
-CONNECTOR_DOCKERFILE=Dockerfile.gcs-buffered-lww
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=gcs_buffered_lww
 WRITE_MODE=buffered
 STATE_BUCKET=asya-state-test
 STORAGE_EMULATOR_HOST=http://fake-gcs:4443

--- a/testing/component/state-proxy/profiles/.env.redis-cas
+++ b/testing/component/state-proxy/profiles/.env.redis-cas
@@ -1,3 +1,4 @@
-CONNECTOR_DOCKERFILE=Dockerfile.redis-buffered-cas
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=redis_buffered_cas
 WRITE_MODE=buffered
 REDIS_URL=redis://redis:6379/0

--- a/testing/component/state-proxy/profiles/.env.s3-cas
+++ b/testing/component/state-proxy/profiles/.env.s3-cas
@@ -1,4 +1,5 @@
-CONNECTOR_DOCKERFILE=Dockerfile.s3-buffered-cas
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=s3_buffered_cas
 WRITE_MODE=buffered
 STATE_BUCKET=asya-state-test
 AWS_ENDPOINT_URL=http://minio:9000

--- a/testing/component/state-proxy/profiles/.env.s3-lww
+++ b/testing/component/state-proxy/profiles/.env.s3-lww
@@ -1,4 +1,5 @@
-CONNECTOR_DOCKERFILE=Dockerfile.s3-buffered-lww
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=s3_buffered_lww
 WRITE_MODE=buffered
 STATE_BUCKET=asya-state-test
 AWS_ENDPOINT_URL=http://minio:9000

--- a/testing/component/state-proxy/profiles/.env.s3-passthrough
+++ b/testing/component/state-proxy/profiles/.env.s3-passthrough
@@ -1,4 +1,5 @@
-CONNECTOR_DOCKERFILE=Dockerfile.s3-passthrough
+CONNECTOR_DOCKERFILE=Dockerfile
+ASYA_CONNECTOR=s3_passthrough
 WRITE_MODE=passthrough
 STATE_BUCKET=asya-state-test
 AWS_ENDPOINT_URL=http://minio:9000

--- a/testing/e2e/charts/asya-test-flows/templates/research-flow-aggregator.yaml
+++ b/testing/e2e/charts/asya-test-flows/templates/research-flow-aggregator.yaml
@@ -11,11 +11,7 @@
 {{- $sp := .Values.stateProxy }}
 {{- $connectorImage := dict "val" $sp.connector.image }}
 {{- if not $connectorImage.val }}
-  {{- if eq $sp.backend "s3" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-s3-buffered-lww:dev" }}
-  {{- else if eq $sp.backend "gcs" }}
-    {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-gcs-buffered-lww:dev" }}
-  {{- end }}
+  {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-py:dev" }}
 {{- end }}
 apiVersion: asya.sh/v1alpha1
 kind: AsyncActor
@@ -37,6 +33,8 @@ spec:
       connector:
         image: {{ $connectorImage.val }}
         env:
+          - name: ASYA_CONNECTOR
+            value: {{ if eq $sp.backend "s3" }}s3_buffered_cas{{ else }}gcs_buffered_cas{{ end }}
           - name: STATE_BUCKET
             value: {{ $sp.config.bucket | quote }}
           {{- if eq $sp.backend "s3" }}

--- a/testing/e2e/profiles/pubsub-gcs.yaml
+++ b/testing/e2e/profiles/pubsub-gcs.yaml
@@ -66,7 +66,7 @@ crew:
       project: test-project
       emulatorHost: "http://gcs-emulator.asya-system.svc.cluster.local:4443"
     connector:
-      image: ghcr.io/deliveryhero/asya-state-proxy-gcs-buffered-lww:dev
+      image: ghcr.io/deliveryhero/asya-state-proxy-py:dev
   x-sink:
     env:
       ASYA_PERSISTENCE_MOUNT: "/state/checkpoints/results"
@@ -109,7 +109,7 @@ gateway:
   stateProxy:
     mesh:
       image:
-        repository: ghcr.io/deliveryhero/asya-state-proxy-pg-kv
+        repository: ghcr.io/deliveryhero/asya-state-proxy-go
         tag: dev
         pullPolicy: Never
   database:

--- a/testing/e2e/profiles/rabbitmq-minio.yaml
+++ b/testing/e2e/profiles/rabbitmq-minio.yaml
@@ -81,7 +81,7 @@ gateway:
   stateProxy:
     mesh:
       image:
-        repository: ghcr.io/deliveryhero/asya-state-proxy-pg-kv
+        repository: ghcr.io/deliveryhero/asya-state-proxy-go
         tag: dev
         pullPolicy: Never
   database:

--- a/testing/e2e/profiles/sqs-s3.yaml
+++ b/testing/e2e/profiles/sqs-s3.yaml
@@ -46,7 +46,7 @@ crew:
     enabled: true
     backend: s3
     connector:
-      image: ghcr.io/deliveryhero/asya-state-proxy-s3-buffered-lww:dev
+      image: ghcr.io/deliveryhero/asya-state-proxy-py:dev
     config:
       bucket: asya-results
       errorsBucket: asya-errors
@@ -100,7 +100,7 @@ gateway:
   stateProxy:
     mesh:
       image:
-        repository: ghcr.io/deliveryhero/asya-state-proxy-pg-kv
+        repository: ghcr.io/deliveryhero/asya-state-proxy-go
         tag: dev
         pullPolicy: Never
   database:

--- a/testing/e2e/scripts/deploy.sh
+++ b/testing/e2e/scripts/deploy.sh
@@ -113,24 +113,18 @@ time {
   docker build -t "function-asya-flavors:latest" "$ROOT_DIR/src/function-asya-flavors/" > /dev/null 2>&1 &
   FUNCTION_BUILD_PID=$!
 
-  # Build PG state-proxy connector (always needed for mesh-api)
-  echo "[.] Building state-proxy pg-kv image..."
-  docker build -t "${IMAGE_PREFIX}asya-state-proxy-pg-kv:dev" \
-    -f "$ROOT_DIR/src/asya-state-proxy/Dockerfile.pg-kv" \
+  # Build state-proxy-go (pg-kv, always needed for mesh-api)
+  echo "[.] Building asya-state-proxy-go image..."
+  docker build -t "${IMAGE_PREFIX}asya-state-proxy-go:dev" \
+    -f "$ROOT_DIR/src/asya-state-proxy/Dockerfile.go" \
     "$ROOT_DIR/src/asya-state-proxy/" > /dev/null 2>&1 &
   PG_KV_BUILD_PID=$!
 
-  # Build state-proxy connector image for the active profile
-  if [[ "$PROFILE" == "sqs-s3" ]]; then
-    echo "[.] Building state-proxy S3 connector image..."
-    docker build -t "${IMAGE_PREFIX}asya-state-proxy-s3-buffered-lww:dev" \
-      -f "$ROOT_DIR/src/asya-state-proxy/Dockerfile.s3-buffered-lww" \
-      "$ROOT_DIR/src/asya-state-proxy/" > /dev/null 2>&1 &
-    STATE_PROXY_BUILD_PID=$!
-  elif [[ "$PROFILE" == "pubsub-gcs" ]]; then
-    echo "[.] Building state-proxy GCS connector image..."
-    docker build -t "${IMAGE_PREFIX}asya-state-proxy-gcs-buffered-lww:dev" \
-      -f "$ROOT_DIR/src/asya-state-proxy/Dockerfile.gcs-buffered-lww" \
+  # Build state-proxy-py (Python connectors, for active profile)
+  if [[ "$PROFILE" == "sqs-s3" ]] || [[ "$PROFILE" == "pubsub-gcs" ]]; then
+    echo "[.] Building asya-state-proxy-py image..."
+    docker build -t "${IMAGE_PREFIX}asya-state-proxy-py:dev" \
+      -f "$ROOT_DIR/src/asya-state-proxy/Dockerfile" \
       "$ROOT_DIR/src/asya-state-proxy/" > /dev/null 2>&1 &
     STATE_PROXY_BUILD_PID=$!
   fi
@@ -149,10 +143,10 @@ time {
   echo "[+] function-asya-flavors image built"
 
   if ! wait "$PG_KV_BUILD_PID"; then
-    echo "[-] state-proxy pg-kv build failed"
+    echo "[-] asya-state-proxy-go build failed"
     exit 1
   fi
-  echo "[+] state-proxy pg-kv image built"
+  echo "[+] asya-state-proxy-go image built"
 
   if [[ -n "${STATE_PROXY_BUILD_PID:-}" ]]; then
     if ! wait "$STATE_PROXY_BUILD_PID"; then
@@ -223,13 +217,11 @@ time {
     "asya-sidecar:latest"
     "asya-crew:latest"
     "asya-testing:latest"
-    "asya-state-proxy-pg-kv:dev"
+    "asya-state-proxy-go:dev"
   )
 
-  if [[ "$PROFILE" == "sqs-s3" ]]; then
-    IMAGES_TO_LOAD+=("asya-state-proxy-s3-buffered-lww:dev")
-  elif [[ "$PROFILE" == "pubsub-gcs" ]]; then
-    IMAGES_TO_LOAD+=("asya-state-proxy-gcs-buffered-lww:dev")
+  if [[ "$PROFILE" == "sqs-s3" ]] || [[ "$PROFILE" == "pubsub-gcs" ]]; then
+    IMAGES_TO_LOAD+=("asya-state-proxy-py:dev")
   fi
 
   LOAD_PIDS=()

--- a/testing/integration/fan-in/compose/actors.yml
+++ b/testing/integration/fan-in/compose/actors.yml
@@ -18,12 +18,13 @@ services:
   state-proxy-connector:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.s3-buffered-cas
+      dockerfile: Dockerfile
     logging: *default-logging
     depends_on:
       storage-setup:
         condition: service_completed_successfully
     environment:
+      ASYA_CONNECTOR: s3_buffered_cas
       CONNECTOR_SOCKET: /var/run/asya/state/fanin.sock
       STATE_BUCKET: asya-state-test
       STATE_PREFIX: fanin

--- a/testing/integration/gateway-actors/compose/crew-gcs-flavor.yml
+++ b/testing/integration/gateway-actors/compose/crew-gcs-flavor.yml
@@ -16,9 +16,10 @@ services:
   asya-x-sink-state-proxy:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.gcs-buffered-lww
+      dockerfile: Dockerfile
     logging: *default-logging
     environment:
+      ASYA_CONNECTOR: gcs_buffered_lww
       CONNECTOR_SOCKET: /var/run/asya/state/results.sock
       STATE_BUCKET: asya-results
       STORAGE_EMULATOR_HOST: http://fake-gcs:4443
@@ -39,9 +40,10 @@ services:
   asya-x-sump-state-proxy:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.gcs-buffered-lww
+      dockerfile: Dockerfile
     logging: *default-logging
     environment:
+      ASYA_CONNECTOR: gcs_buffered_lww
       CONNECTOR_SOCKET: /var/run/asya/state/errors.sock
       STATE_BUCKET: asya-errors
       STORAGE_EMULATOR_HOST: http://fake-gcs:4443

--- a/testing/integration/stateful-actors/compose/actors.yml
+++ b/testing/integration/stateful-actors/compose/actors.yml
@@ -18,12 +18,13 @@ services:
   state-proxy-connector:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.s3-buffered-lww
+      dockerfile: Dockerfile
     logging: *default-logging
     depends_on:
       storage-setup:
         condition: service_completed_successfully
     environment:
+      ASYA_CONNECTOR: s3_buffered_lww
       CONNECTOR_SOCKET: /var/run/asya/state/meta.sock
       STATE_BUCKET: asya-state-test
       STATE_PREFIX: integration

--- a/testing/shared/compose/asya/gateway.yml
+++ b/testing/shared/compose/asya/gateway.yml
@@ -36,7 +36,7 @@ services:
   pg-kv:
     build:
       context: ../../../../src/asya-state-proxy
-      dockerfile: Dockerfile.pg-kv
+      dockerfile: Dockerfile.go
       target: builder
     logging: *default-logging
     command: ["go", "run", "./cmd/pg-kv/"]


### PR DESCRIPTION
## Summary

- Merges 7 per-backend Dockerfiles into two images:
  - **`asya-state-proxy-py`** — single Python image with all connectors (S3 LWW/CAS/passthrough, GCS LWW/CAS, Redis CAS); connector selected at runtime via `ASYA_CONNECTOR` env var
  - **`asya-state-proxy-go`** — Go pg-kv binary (renamed from `Dockerfile.pg-kv`, no logic change)
- Adds both images to `src/build-images.sh` via `get_build_context` / `get_dockerfile` helpers

## Test plan

- [ ] `./src/build-images.sh asya-state-proxy-py` builds successfully
- [ ] `./src/build-images.sh asya-state-proxy-go` builds successfully
- [ ] `ASYA_CONNECTOR=s3_buffered_lww docker run asya-state-proxy-py` starts the correct connector
- [ ] `make build-images` includes both new images