### PR TITLE
ci: skip DCO and PR title checks for bot-authored PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,7 +11,9 @@ jobs:
   dco-check:
     name: DCO Sign-off
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
     - name: Check DCO sign-off

--- a/.github/workflows/pr-commit.yml
+++ b/.github/workflows/pr-commit.yml
@@ -12,7 +12,9 @@ jobs:
   validate-title:
     name: Validate PR title
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
     - name: Check for Semantic Title


### PR DESCRIPTION
## Summary

Fixes the root cause of the changelog PR CI failure: `github.actor` is who *triggered* the workflow run (can be a human reopening/editing the PR), not who created the PR. Using `github.event.pull_request.user.login` correctly identifies bot-authored PRs regardless of who triggers subsequent workflow runs.

- **`dco.yml`**: skip DCO check when PR author is `github-actions[bot]` or `dependabot[bot]`
- **`pr-commit.yml`**: skip semantic title check on the same condition

Once merged, re-triggering checks on PR #453 will correctly skip DCO.

## Test plan

- [ ] Merge and re-trigger PR #453 checks — DCO should be skipped
- [ ] Verify human-authored PRs still require DCO sign-off