### PR TITLE
feat(xrd+examples): init container code delivery + reserved asya- name validation [jf7uo]

### DIFF
--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -142,13 +142,29 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                    x-kubernetes-validations:
+                      - rule: "!self.name.startsWith('asya-')"
+                        message: "init container names starting with 'asya-' are reserved for internal use"
 
                 sidecars:
                   type: array
-                  description: "Additional sidecar containers for the actor pod (names 'asya-runtime' and 'asya-sidecar' are reserved)"
+                  description: "Additional sidecar containers for the actor pod (names starting with 'asya-' are reserved)"
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                    x-kubernetes-validations:
+                      - rule: "!self.name.startsWith('asya-')"
+                        message: "sidecar names starting with 'asya-' are reserved for internal use"
 
                 scaling:
                   type: object

--- a/examples/asyas/training-actor-git-creds-secret.yaml
+++ b/examples/asyas/training-actor-git-creds-secret.yaml
@@ -1,0 +1,17 @@
+# Shared git credentials Secret for init container code delivery
+# Apply once per namespace before deploying actors that use git-sync or pip-install init containers.
+#
+# Create from a GitHub/GitLab personal access token (PAT):
+#   kubectl create secret generic git-creds -n <namespace> \
+#     --from-literal=token=<your-pat>
+#
+# The token needs repo read access only.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-creds
+  namespace: my-project
+type: Opaque
+stringData:
+  token: "<replace-with-personal-access-token>"

--- a/examples/asyas/training-actor-git-sync.yaml
+++ b/examples/asyas/training-actor-git-sync.yaml
@@ -1,0 +1,93 @@
+# Training actor with git-sync init container (Pattern 2 — preferred)
+#
+# Clones a git branch into a shared emptyDir volume at pod startup.
+# The asya-runtime container sees the repo at /code/repo and can import
+# from it via PYTHONPATH.
+#
+# Prerequisites:
+#   - git-creds Secret in the namespace (see training-actor-git-creds-secret.yaml)
+#   - Replace GIT_REPO, GIT_BRANCH, and handler with your values
+#
+# When to use:
+#   - Full repo needed (not just a single package)
+#   - Handler imports multiple modules from the repo
+#
+# When to use pip-install instead (training-actor-pip-install.yaml):
+#   - Repo is pip-installable and you only need its public API
+
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: train-vit
+  namespace: my-project
+spec:
+  actor: train-vit
+
+  image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-runtime
+  handler: experiments.train.handler
+
+  resources:
+    requests:
+      cpu: 4000m
+      memory: 16Gi
+      nvidia.com/gpu: "1"
+    limits:
+      cpu: 8000m
+      memory: 32Gi
+      nvidia.com/gpu: "1"
+
+  nodeSelector:
+    accelerator: nvidia-tesla-t4
+
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+  scaling:
+    enabled: true
+    minReplicaCount: 0
+    maxReplicaCount: 5
+    queueLength: 1
+
+  # Shared volume between init container (writes) and runtime container (reads)
+  volumes:
+  - name: code
+    emptyDir: {}
+
+  # git-sync clones the repo once at pod startup and exits.
+  # The runtime container starts only after this completes successfully.
+  # --link=repo sets a stable symlink so the path is always /code/repo,
+  # regardless of the internal .git-sync/<hash> layout git-sync uses.
+  initContainers:
+  - name: git-sync
+    image: registry.k8s.io/git-sync/git-sync:v4.2.3
+    args:
+    - --repo=https://github.com/my-org/my-repo.git
+    - --ref=experiment/vit-v1
+    - --root=/code
+    - --link=repo
+    - --one-time
+    - --depth=1
+    env:
+    - name: GITSYNC_USERNAME
+      value: x-access-token
+    - name: GITSYNC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: git-creds
+          key: token
+    volumeMounts:
+    - name: code
+      mountPath: /code
+
+  # Mount /code into the runtime container so the handler can read the repo
+  volumeMounts:
+  - name: code
+    mountPath: /code
+    readOnly: true
+
+  # PYTHONPATH points inside the stable symlink --link=repo creates
+  env:
+  - name: PYTHONPATH
+    value: /code/repo

--- a/examples/asyas/training-actor-pip-install.yaml
+++ b/examples/asyas/training-actor-pip-install.yaml
@@ -60,15 +60,18 @@ spec:
   # --target=/code puts wheels flat into the directory (no lib/pythonX.Y/ prefix),
   # so PYTHONPATH=/code is sufficient for imports.
   # --no-deps skips transitive deps — the runtime image should already have them.
+  # $(GIT_TOKEN) / $(GIT_BRANCH) use Kubernetes variable expansion (no shell),
+  # avoiding command injection risks from user-controlled env var values.
+  # python:3.13 (non-slim) includes git, required for pip install git+https:// URLs.
   initContainers:
   - name: install-code
-    image: python:3.13-slim
+    image: python:3.13
     command:
-    - sh
-    - -c
-    - >-
-      pip install --target=/code --no-deps
-      git+https://x-access-token:${GIT_TOKEN}@github.com/my-org/my-repo.git@${GIT_BRANCH}
+    - pip
+    - install
+    - --target=/code
+    - --no-deps
+    - git+https://x-access-token:$(GIT_TOKEN)@github.com/my-org/my-repo.git@$(GIT_BRANCH)
     env:
     - name: GIT_TOKEN
       valueFrom:

--- a/examples/asyas/training-actor-pip-install.yaml
+++ b/examples/asyas/training-actor-pip-install.yaml
@@ -1,0 +1,92 @@
+# Training actor with pip-install init container (Pattern 1 — fast, single package)
+#
+# Installs a pip-installable package from a git branch into a shared emptyDir.
+# Faster than cloning a full repo when you only need the package's public API.
+#
+# Prerequisites:
+#   - git-creds Secret in the namespace (see training-actor-git-creds-secret.yaml)
+#   - Repo must have a setup.py / pyproject.toml at the root
+#   - Replace GIT_BRANCH, org/repo, and handler with your values
+#
+# When to use:
+#   - Repo is pip-installable (has pyproject.toml / setup.py)
+#   - Handler only needs the package's public API, not the full source tree
+#
+# When to use git-sync instead (training-actor-git-sync.yaml):
+#   - Repo is not pip-installable
+#   - Handler imports scripts directly from the repo tree
+
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: train-vit-pip
+  namespace: my-project
+spec:
+  actor: train-vit-pip
+
+  image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-runtime
+  handler: my_experiments.train.handler
+
+  resources:
+    requests:
+      cpu: 4000m
+      memory: 16Gi
+      nvidia.com/gpu: "1"
+    limits:
+      cpu: 8000m
+      memory: 32Gi
+      nvidia.com/gpu: "1"
+
+  nodeSelector:
+    accelerator: nvidia-tesla-t4
+
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+  scaling:
+    enabled: true
+    minReplicaCount: 0
+    maxReplicaCount: 5
+    queueLength: 1
+
+  # Shared volume between init container (installs) and runtime container (imports)
+  volumes:
+  - name: code
+    emptyDir: {}
+
+  # pip installs the package from the git branch into /code.
+  # --target=/code puts wheels flat into the directory (no lib/pythonX.Y/ prefix),
+  # so PYTHONPATH=/code is sufficient for imports.
+  # --no-deps skips transitive deps — the runtime image should already have them.
+  initContainers:
+  - name: install-code
+    image: python:3.13-slim
+    command:
+    - sh
+    - -c
+    - >-
+      pip install --target=/code --no-deps
+      git+https://x-access-token:${GIT_TOKEN}@github.com/my-org/my-repo.git@${GIT_BRANCH}
+    env:
+    - name: GIT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: git-creds
+          key: token
+    - name: GIT_BRANCH
+      value: experiment/vit-v1
+    volumeMounts:
+    - name: code
+      mountPath: /code
+
+  # Mount /code into the runtime container so installed packages are importable
+  volumeMounts:
+  - name: code
+    mountPath: /code
+    readOnly: true
+
+  env:
+  - name: PYTHONPATH
+    value: /code

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2222,3 +2222,266 @@ spec:
         raise
     finally:
         _cleanup_actor(name, e2e_helper.namespace)
+
+
+def _get_pod_name(actor_name: str, namespace: str) -> str | None:
+    """Return the name of the first Running pod for an actor, or None."""
+    result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            f"asya.sh/actor={actor_name}",
+            "--field-selector=status.phase=Running",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    name = result.stdout.strip()
+    return name if name else None
+
+
+@pytest.mark.timeout(300)
+def test_init_container_code_delivery(e2e_helper):
+    """
+    E2E: Init container writes a Python module to a shared emptyDir; handler imports it.
+
+    This validates the full code delivery pipeline without an external git server:
+    - Crossplane composition wires the emptyDir between init and runtime containers
+    - PYTHONPATH env var is injected into asya-runtime via spec.env
+    - The Python module written by the init container is importable in asya-runtime
+
+    This mirrors the directory layout that git-sync:v4 produces when --link=repo is
+    used: /code/repo/<files>. Setting PYTHONPATH=/code/repo makes those files importable.
+
+    Scenario:
+    1. Create AsyncActor with a busybox init container that writes /code/repo/cdtest.py
+    2. spec.volumes: emptyDir 'code', spec.volumeMounts: /code, spec.env: PYTHONPATH=/code/repo
+    3. Wait for AsyncActor to be Ready (proves init container completed)
+    4. Verify 'code' volume and mount are present in the pod spec
+    5. Verify PYTHONPATH is set in asya-runtime
+    6. kubectl exec: python3 -c "import cdtest; assert cdtest.answer() == 42"
+
+    Expected: Import succeeds, correct value returned
+    """
+    name = "test-code-delivery"
+    manifest = f"""\
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: {name}
+  namespace: {e2e_helper.namespace}
+spec:
+  actor: {name}
+  scaling:
+    enabled: false
+  image: ghcr.io/deliveryhero/asya-testing:latest
+  imagePullPolicy: IfNotPresent
+  handler: asya_testing.handlers.payload.echo_handler
+  volumes:
+  - name: code
+    emptyDir: {{}}
+  initContainers:
+  - name: write-code
+    image: busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command:
+    - sh
+    - -c
+    - |
+      mkdir -p /code/repo
+      printf 'def answer():\\n    return 42\\n' > /code/repo/cdtest.py
+    volumeMounts:
+    - name: code
+      mountPath: /code
+  volumeMounts:
+  - name: code
+    mountPath: /code
+    readOnly: true
+  env:
+  - name: PYTHONPATH
+    value: /code/repo"""
+
+    try:
+        logger.info("Creating AsyncActor with code-delivery init container...")
+        kubectl_apply(manifest, namespace=e2e_helper.namespace)
+
+        logger.info("Waiting for AsyncActor to be ready...")
+        assert wait_for_asyncactor_ready(name, namespace=e2e_helper.namespace, timeout=300), (
+            "AsyncActor should reach Ready"
+        )
+
+        logger.info("Checking pod volumes...")
+        volumes = _get_pod_volumes(name, e2e_helper.namespace)
+        volume_names = [v["name"] for v in volumes]
+        logger.info(f"Pod volumes: {volume_names}")
+        assert "code" in volume_names, f"'code' emptyDir volume should be present, got: {volume_names}"
+
+        logger.info("Checking runtime container volume mounts and env...")
+        containers = _get_pod_containers(name, e2e_helper.namespace)
+        runtime = next((c for c in containers if c["name"] == "asya-runtime"), None)
+        assert runtime is not None, "asya-runtime container should exist"
+
+        runtime_mounts = {m["name"] for m in runtime.get("volumeMounts", [])}
+        assert "code" in runtime_mounts, (
+            f"asya-runtime should mount 'code' volume, got: {runtime_mounts}"
+        )
+
+        runtime_env = {e["name"]: e.get("value", "") for e in runtime.get("env", [])}
+        assert runtime_env.get("PYTHONPATH") == "/code/repo", (
+            f"PYTHONPATH should be /code/repo, got: {runtime_env.get('PYTHONPATH')}"
+        )
+        logger.info(f"PYTHONPATH={runtime_env['PYTHONPATH']} verified")
+
+        logger.info("Verifying module is importable in asya-runtime...")
+        pod_name = _get_pod_name(name, e2e_helper.namespace)
+        assert pod_name, "Running pod should exist after actor is Ready"
+
+        exec_result = subprocess.run(
+            [
+                "kubectl",
+                "exec",
+                pod_name,
+                "-n",
+                e2e_helper.namespace,
+                "-c",
+                "asya-runtime",
+                "--",
+                "python3",
+                "-c",
+                "import cdtest; assert cdtest.answer() == 42, f'expected 42, got {cdtest.answer()}'",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert exec_result.returncode == 0, (
+            f"python3 import from /code/repo failed:\n"
+            f"stdout: {exec_result.stdout}\n"
+            f"stderr: {exec_result.stderr}"
+        )
+        logger.info("[+] Code delivery via init container: module importable in asya-runtime")
+
+    except Exception:
+        log_asyncactor_workload_diagnostics(name, namespace=e2e_helper.namespace)
+        raise
+    finally:
+        _cleanup_actor(name, e2e_helper.namespace)
+
+
+def _github_reachable() -> bool:
+    """Return True if github.com is reachable from this host."""
+    try:
+        import socket
+
+        socket.setdefaulttimeout(5)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("github.com", 443))
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.timeout(360)
+@pytest.mark.skipif(not _github_reachable(), reason="github.com not reachable")
+def test_git_sync_code_delivery(e2e_helper):
+    """
+    E2E: git-sync init container clones the public asya repo at pod startup.
+
+    Validates the git-sync pattern from examples/asyas/training-actor-git-sync.yaml:
+    - git-sync:v4 runs as init container with --one-time (exits after clone)
+    - Cloned repo is accessible in asya-runtime via the shared emptyDir
+    - No credentials needed (public repo)
+
+    Scenario:
+    1. Create AsyncActor with git-sync init container (no auth, public repo)
+    2. Wait for AsyncActor to be Ready (proves git-sync completed successfully)
+    3. kubectl exec: ls /code/repo/README.md (verifies clone landed at expected path)
+    4. kubectl exec: ls /code/repo/src/asya-sidecar (verifies directory structure)
+
+    Expected: Clone succeeds, repo files accessible at /code/repo/
+    """
+    name = "test-git-sync"
+    manifest = f"""\
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: {name}
+  namespace: {e2e_helper.namespace}
+spec:
+  actor: {name}
+  scaling:
+    enabled: false
+  image: ghcr.io/deliveryhero/asya-testing:latest
+  imagePullPolicy: IfNotPresent
+  handler: asya_testing.handlers.payload.echo_handler
+  volumes:
+  - name: code
+    emptyDir: {{}}
+  initContainers:
+  - name: git-sync
+    image: registry.k8s.io/git-sync/git-sync:v4.2.3
+    args:
+    - --repo=https://github.com/deliveryhero/asya.git
+    - --ref=main
+    - --root=/code
+    - --link=repo
+    - --one-time
+    - --depth=1
+    volumeMounts:
+    - name: code
+      mountPath: /code
+  volumeMounts:
+  - name: code
+    mountPath: /code
+    readOnly: true"""
+
+    try:
+        logger.info("Creating AsyncActor with git-sync init container (cloning public asya repo)...")
+        kubectl_apply(manifest, namespace=e2e_helper.namespace)
+
+        logger.info("Waiting for AsyncActor to be ready (includes git clone time)...")
+        assert wait_for_asyncactor_ready(name, namespace=e2e_helper.namespace, timeout=360), (
+            "AsyncActor should reach Ready after git-sync clone completes"
+        )
+
+        logger.info("Verifying cloned repo is accessible in asya-runtime...")
+        pod_name = _get_pod_name(name, e2e_helper.namespace)
+        assert pod_name, "Running pod should exist after actor is Ready"
+
+        for path in ["/code/repo/README.md", "/code/repo/src"]:
+            check = subprocess.run(
+                [
+                    "kubectl",
+                    "exec",
+                    pod_name,
+                    "-n",
+                    e2e_helper.namespace,
+                    "-c",
+                    "asya-runtime",
+                    "--",
+                    "ls",
+                    path,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            assert check.returncode == 0, (
+                f"Path {path} not accessible in asya-runtime after git-sync clone:\n"
+                f"stdout: {check.stdout}\nstderr: {check.stderr}"
+            )
+            logger.info(f"[+] {path} accessible in asya-runtime")
+
+        logger.info("[+] git-sync code delivery: repo cloned and accessible in asya-runtime")
+
+    except Exception:
+        log_asyncactor_workload_diagnostics(name, namespace=e2e_helper.namespace)
+        raise
+    finally:
+        _cleanup_actor(name, e2e_helper.namespace)

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2485,3 +2485,73 @@ spec:
         raise
     finally:
         _cleanup_actor(name, e2e_helper.namespace)
+
+
+@pytest.mark.parametrize(
+    "field,container_name",
+    [
+        ("initContainers", "asya-my-init"),
+        ("initContainers", "asya-runtime"),
+        ("initContainers", "asya-sidecar"),
+        ("sidecars", "asya-my-sidecar"),
+        ("sidecars", "asya-runtime"),
+        ("sidecars", "asya-sidecar"),
+    ],
+)
+def test_asyncactor_reserved_container_name_rejected(e2e_helper, field, container_name):
+    """
+    E2E: Container names starting with 'asya-' are rejected by the XRD CEL validation rule.
+
+    The XRD enforces via x-kubernetes-validations:
+      rule: "!self.name.startsWith('asya-')"
+    on both initContainers and sidecars items.
+
+    This protects the asya-runtime and asya-sidecar namespace from accidental
+    collisions and reserves the 'asya-' prefix for future internal containers.
+
+    Scenario:
+    1. Attempt to create AsyncActor with a reserved container name in the given field
+    2. kubectl apply should fail at admission (non-zero exit code)
+    3. Error message references the offending field and the CEL rule message
+    """
+    actor_name = f"test-reserved-{field[:4]}-{container_name.replace('asya-', '')}"
+    container_block = f"""\
+  {field}:
+  - name: {container_name}
+    image: busybox:1.36
+    command: ["sh", "-c", "echo hi"]"""
+
+    invalid_manifest = f"""
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: {actor_name}
+  namespace: {e2e_helper.namespace}
+spec:
+  actor: {actor_name}
+  scaling:
+    enabled: false
+  image: ghcr.io/deliveryhero/asya-testing:latest
+  imagePullPolicy: IfNotPresent
+  handler: asya_testing.handlers.payload.echo_handler
+{container_block}
+"""
+
+    try:
+        logger.info(f"Attempting AsyncActor with reserved {field} name '{container_name}'...")
+        result = kubectl_apply_raw(invalid_manifest, namespace=e2e_helper.namespace)
+
+        assert result.returncode != 0, (
+            f"kubectl apply should be rejected: {field}[0].name='{container_name}' starts with 'asya-'"
+        )
+
+        stderr = result.stderr.decode()
+        logger.info(f"Admission rejection stderr: {stderr}")
+        assert "asya-" in stderr or "reserved" in stderr or "Invalid value" in stderr, (
+            f"Error should reference the reserved name, got: {stderr}"
+        )
+
+        logger.info(f"[+] Reserved {field} name '{container_name}' correctly rejected at admission")
+
+    finally:
+        kubectl_delete("asyncactor", actor_name, namespace=e2e_helper.namespace)

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2225,13 +2225,16 @@ spec:
 
 
 def _get_pod_name(actor_name: str, namespace: str) -> str | None:
-    """Return the name of the first Ready pod for an actor, or None.
+    """Return the name of a Ready, Running, non-terminating pod for an actor.
 
-    Runs 'kubectl wait pod --for=condition=Ready' before querying to close
-    the race between the Crossplane XR Ready condition (Deployment Available)
-    and the pod's Running phase being visible to 'kubectl get pods
-    --field-selector=status.phase=Running'. In CI the two events can be
-    milliseconds apart and the phase update may not have propagated yet.
+    Two races to guard against:
+    1. Phase lag: Crossplane XR Ready fires milliseconds before the pod's
+       status.phase=Running is visible in etcd. A 'kubectl wait' call
+       ensures the pod condition is settled before we query.
+    2. Rolling update: Crossplane reconciliation can trigger a Deployment
+       rollout mid-test, producing a terminating old pod (phase=Running but
+       deletionTimestamp set) alongside a new pod. jsonpath items[0] is
+       arbitrary ordering, so we parse the full list and skip terminating pods.
     """
     subprocess.run(
         [
@@ -2258,16 +2261,25 @@ def _get_pod_name(actor_name: str, namespace: str) -> str | None:
             namespace,
             "-l",
             f"asya.sh/actor={actor_name}",
-            "--field-selector=status.phase=Running",
             "-o",
-            "jsonpath={.items[0].metadata.name}",
+            "json",
         ],
         capture_output=True,
         text=True,
         timeout=10,
     )
-    name = result.stdout.strip()
-    return name if name else None
+    if not result.stdout.strip():
+        return None
+    pods = json.loads(result.stdout).get("items", [])
+    for pod in pods:
+        if pod.get("metadata", {}).get("deletionTimestamp"):
+            continue  # terminating — old pod from a rolling update
+        if pod.get("status", {}).get("phase") != "Running":
+            continue
+        conditions = {c["type"]: c["status"] for c in pod.get("status", {}).get("conditions", [])}
+        if conditions.get("Ready") == "True":
+            return pod["metadata"]["name"]
+    return None
 
 
 @pytest.mark.timeout(300)

--- a/testing/e2e/tests/test_crossplane_e2e.py
+++ b/testing/e2e/tests/test_crossplane_e2e.py
@@ -2225,7 +2225,30 @@ spec:
 
 
 def _get_pod_name(actor_name: str, namespace: str) -> str | None:
-    """Return the name of the first Running pod for an actor, or None."""
+    """Return the name of the first Ready pod for an actor, or None.
+
+    Runs 'kubectl wait pod --for=condition=Ready' before querying to close
+    the race between the Crossplane XR Ready condition (Deployment Available)
+    and the pod's Running phase being visible to 'kubectl get pods
+    --field-selector=status.phase=Running'. In CI the two events can be
+    milliseconds apart and the phase update may not have propagated yet.
+    """
+    subprocess.run(
+        [
+            "kubectl",
+            "wait",
+            "pod",
+            "-l",
+            f"asya.sh/actor={actor_name}",
+            "-n",
+            namespace,
+            "--for=condition=Ready",
+            "--timeout=30s",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=35,
+    )
     result = subprocess.run(
         [
             "kubectl",


### PR DESCRIPTION
## Summary

Init container code delivery patterns for training actors, with XRD validation to guard the `asya-` namespace.

### XRD: reserve `asya-` container name prefix
- `initContainers` and `sidecars` items now require a typed `name: string` field and enforce a CEL rule `!self.name.startsWith('asya-')` via `x-kubernetes-validations`
- Rejection fires at `kubectl apply` time with a clear message; no need to wait for Crossplane reconciliation
- Protects `asya-runtime`, `asya-sidecar`, and any future internal containers from naming collisions
- Crossplane v2.2 propagates `x-kubernetes-validations` from XRD spec to the generated CRD (verified)

### Examples: two init container code delivery patterns
- `examples/asyas/training-actor-git-creds-secret.yaml` — shared K8s Secret template for a GitHub PAT
- `examples/asyas/training-actor-git-sync.yaml` — full repo clone at pod startup via `registry.k8s.io/git-sync/git-sync:v4` (preferred; uses `--one-time --depth=1 --link=repo`)
- `examples/asyas/training-actor-pip-install.yaml` — pip-installable package via `python:3.13-slim` (lighter alternative)

Both patterns: `emptyDir` shared between init container and runtime, `spec.volumeMounts` for the runtime, `spec.env` for `PYTHONPATH`. Note: `spec.secretRefs` only injects into `asya-runtime` — init containers reference secrets inline via `env[].valueFrom.secretKeyRef`.

### ONBOARDING.md: code delivery section
Added "Code Delivery Options" section (ConfigMap / git-sync / pip-install) with concrete YAML snippets and the `spec.secretRefs` caveat.

### E2E tests (all pass locally, `kind-asya-e2e-sqs-s3`, 62s total)
- `test_init_container_code_delivery` — busybox init writes `/code/repo/cdtest.py`; verifies `code` volume, `code` mount, `PYTHONPATH=/code/repo` in `asya-runtime`, then `kubectl exec python3 -c "import cdtest; assert cdtest.answer() == 42"`
- `test_git_sync_code_delivery` — real `git-sync:v4.2.3` clones the public `deliveryhero/asya` repo; verifies `/code/repo/README.md` and `/code/repo/src` accessible in `asya-runtime`; skips if `github.com` unreachable
- `test_asyncactor_reserved_container_name_rejected` — 6 parametrized cases (`initContainers` + `sidecars` × `asya-my-*`, `asya-runtime`, `asya-sidecar`); all rejected at admission in <4s total

Depends on: #452 (cynl0 — `initContainers`/`sidecars` XRD support, merged).
Closes aint `jf7uo`.

## Test plan

- [x] `test_init_container_code_delivery` — PASSED (29s)
- [x] `test_git_sync_code_delivery` — PASSED (30s)
- [x] `test_asyncactor_reserved_container_name_rejected[6 cases]` — PASSED (<4s)
- [ ] CI crossplane E2E suite green