### PR TITLE
feat(helm): split image values into repository+tag across all charts [dvgpp]

### DIFF
--- a/deploy/helm-charts/asya-crew/templates/_helpers.tpl
+++ b/deploy/helm-charts/asya-crew/templates/_helpers.tpl
@@ -235,15 +235,12 @@ If "bucket" key is absent, falls back to .Values.persistence.config.bucket.
 {{- define "asya-crew.persistence.stateProxy" -}}
 {{- $values := .Values }}
 {{- $bucket := default $values.persistence.config.bucket .bucket }}
-{{- $connectorImage := dict "val" $values.persistence.connector.image }}
-{{- if not $connectorImage.val }}
-  {{- $_ := set $connectorImage "val" (printf "ghcr.io/deliveryhero/asya-state-proxy-py:%s" $.Chart.AppVersion) }}
-{{- end }}
+{{- $connectorImage := printf "%s:%s" $values.persistence.connector.image.repository ($values.persistence.connector.image.tag | default $.Chart.AppVersion) }}
 - name: checkpoints
   mount:
     path: /state/checkpoints
   connector:
-    image: {{ $connectorImage.val }}
+    image: {{ $connectorImage }}
     env:
       - name: ASYA_CONNECTOR
         value: {{ if eq $values.persistence.backend "s3" }}s3_buffered_lww{{ else }}gcs_buffered_lww{{ end }}

--- a/deploy/helm-charts/asya-crew/templates/_helpers.tpl
+++ b/deploy/helm-charts/asya-crew/templates/_helpers.tpl
@@ -229,13 +229,13 @@ helm.sh/chart: {{ include "asya-crew.chart" . }}
 
 {{/*
 Persistence stateProxy spec (inline on AsyncActor, read by Crossplane composition from XR spec)
-Call with bucket name override via dict: include "asya-crew.persistence.stateProxy" (dict "Values" .Values "bucket" "my-bucket")
+Call with bucket name override via dict: include "asya-crew.persistence.stateProxy" (dict "Values" .Values "Chart" .Chart "bucket" "my-bucket")
 If "bucket" key is absent, falls back to .Values.persistence.config.bucket.
 */}}
 {{- define "asya-crew.persistence.stateProxy" -}}
 {{- $values := .Values }}
 {{- $bucket := default $values.persistence.config.bucket .bucket }}
-{{- $connectorImage := printf "%s:%s" $values.persistence.connector.image.repository ($values.persistence.connector.image.tag | default $.Chart.AppVersion) }}
+{{- $connectorImage := printf "%s:%s" $values.persistence.connector.image.repository ($values.persistence.connector.image.tag | default .Chart.AppVersion) }}
 - name: checkpoints
   mount:
     path: /state/checkpoints

--- a/deploy/helm-charts/asya-crew/templates/persistence-flavor.yaml
+++ b/deploy/helm-charts/asya-crew/templates/persistence-flavor.yaml
@@ -5,10 +5,7 @@
 {{- if not .Values.persistence.config.bucket }}
 {{- fail "persistence.config.bucket is required when persistence.enabled is true" }}
 {{- end }}
-{{- $connectorImage := dict "val" .Values.persistence.connector.image }}
-{{- if not $connectorImage.val }}
-  {{- $_ := set $connectorImage "val" (printf "ghcr.io/deliveryhero/asya-state-proxy-py:%s" .Chart.AppVersion) }}
-{{- end }}
+{{- $connectorImage := printf "%s:%s" .Values.persistence.connector.image.repository (.Values.persistence.connector.image.tag | default .Chart.AppVersion) }}
 apiVersion: apiextensions.crossplane.io/v1beta1
 kind: EnvironmentConfig
 metadata:
@@ -22,7 +19,7 @@ data:
       mount:
         path: /state/checkpoints
       connector:
-        image: {{ $connectorImage.val }}
+        image: {{ $connectorImage }}
         env:
           - name: ASYA_CONNECTOR
             value: {{ if eq .Values.persistence.backend "s3" }}s3_buffered_lww{{ else }}gcs_buffered_lww{{ end }}

--- a/deploy/helm-charts/asya-crew/templates/sump.yaml
+++ b/deploy/helm-charts/asya-crew/templates/sump.yaml
@@ -16,7 +16,7 @@ spec:
   {{- include "asya-crew.pubsub-spec" . | nindent 2 }}
   {{- if .Values.persistence.enabled }}
   stateProxy:
-    {{- include "asya-crew.persistence.stateProxy" (dict "Values" .Values "bucket" .Values.persistence.config.errorsBucket) | nindent 4 }}
+    {{- include "asya-crew.persistence.stateProxy" (dict "Values" .Values "Chart" .Chart "bucket" .Values.persistence.config.errorsBucket) | nindent 4 }}
   {{- end }}
 
   {{- if .Values.tracing.endpoint }}

--- a/deploy/helm-charts/asya-crew/values.yaml
+++ b/deploy/helm-charts/asya-crew/values.yaml
@@ -281,7 +281,9 @@ persistence:
       maxKeys: "" # QUERY_MAX_KEYS: max objects listed before returning 400 (default 10000)
       maxResultRows: "" # QUERY_MAX_RESULT_ROWS: SQL LIMIT cap on returned rows (default 10000)
   connector:
-    image: "" # auto-selected based on backend if not set
+    image:
+      repository: ghcr.io/deliveryhero/asya-state-proxy-py
+      tag: "" # defaults to Chart.AppVersion
 
 # SQS DLQ queue configuration
 # When enabled, a shared dead-letter queue is created via Crossplane for the namespace.

--- a/deploy/helm-charts/asya-crossplane/README.md
+++ b/deploy/helm-charts/asya-crossplane/README.md
@@ -64,6 +64,24 @@ helm install asya-crossplane deploy/helm-charts/asya-crossplane \
 | `kubernetesProviderConfig.name` | ProviderConfig name | `in-cluster` |
 | `kubernetesProviderConfig.credentialsSource` | Credentials source | `InjectedIdentity` |
 
+### Sidecar Configuration
+
+The sidecar image is injected into every actor pod by the Crossplane composition. These values are
+baked into the composition at `helm install/upgrade` time and apply to all actors in the cluster.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `sidecar.image.repository` | Sidecar container image repository | `ghcr.io/deliveryhero/asya-sidecar` |
+| `sidecar.image.tag` | Sidecar image tag (empty = Chart.AppVersion) | `""` |
+| `sidecar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+
+To pin the sidecar to a specific release:
+
+```bash
+helm upgrade asya-crossplane deploy/helm-charts/asya-crossplane \
+  --set sidecar.image.tag=v0.5.12
+```
+
 ## AsyncActor Spec
 
 The AsyncActor XRD uses a flat spec — all fields live directly under `spec` with no nesting.
@@ -125,7 +143,8 @@ The XRD validates fields at Kubernetes admission time using OpenAPI constraints:
 |-------|-------|-----|
 | `transport in body should be one of [sqs rabbitmq pubsub]` | Invalid transport | Use one of the listed values |
 | `handler in body should be at least 1 chars long` | Empty handler | Set a non-empty handler dotted path |
-| `imagePullPolicy in body should be one of [Always IfNotPresent Never]` | Invalid pull policy | Use one of the listed values |
+| `imagePullPolicy in body should be one of [Always IfNotPresent Never]` | Invalid pull policy on actor runtime container | Use one of the listed values |
+| `sidecar.image.pullPolicy in body should be one of [Always IfNotPresent Never]` | Invalid pull policy on sidecar container | Use one of the listed values |
 
 ## Example AsyncActor Claim
 

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -560,6 +560,7 @@ spec:
                         {{`{{- range $xrSpec.stateProxy | default list }}`}}
                         - name: asya-state-proxy-{{`{{ .name }}`}}
                           image: {{`{{ .connector.image }}`}}
+                          imagePullPolicy: {{`{{ .connector.imagePullPolicy | default "IfNotPresent" }}`}}
                           env:
                           - name: CONNECTOR_SOCKET
                             value: /var/run/asya/state/{{`{{ .name }}`}}.sock

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -345,8 +345,8 @@ spec:
             {{`{{- $socketDir := "`}}{{ .Values.sidecar.socketDir | default "/var/run/asya" }}{{`" -}}`}}
             {{`{{- $runtimeMountPath := "`}}{{ .Values.sidecar.runtimeMountPath | default "/opt/asya/asya_runtime.py" }}{{`" -}}`}}
             {{`{{- $runtimeConfigMap := "`}}{{ .Values.sidecar.runtimeConfigMap | default "asya-runtime" }}{{`" -}}`}}
-            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
-            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
+            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}{{`" -}}`}}
+            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.image.pullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -249,8 +249,8 @@ spec:
             {{`{{- $socketDir := "`}}{{ .Values.sidecar.socketDir | default "/var/run/asya" }}{{`" -}}`}}
             {{`{{- $runtimeMountPath := "`}}{{ .Values.sidecar.runtimeMountPath | default "/opt/asya/asya_runtime.py" }}{{`" -}}`}}
             {{`{{- $runtimeConfigMap := "`}}{{ .Values.sidecar.runtimeConfigMap | default "asya-runtime" }}{{`" -}}`}}
-            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
-            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
+            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}{{`" -}}`}}
+            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.image.pullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -460,6 +460,7 @@ spec:
                         {{`{{- range $xrSpec.stateProxy | default list }}`}}
                         - name: asya-state-proxy-{{`{{ .name }}`}}
                           image: {{`{{ .connector.image }}`}}
+                          imagePullPolicy: {{`{{ .connector.imagePullPolicy | default "IfNotPresent" }}`}}
                           env:
                           - name: CONNECTOR_SOCKET
                             value: /var/run/asya/state/{{`{{ .name }}`}}.sock

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -361,8 +361,8 @@ spec:
             {{`{{- $socketDir := "`}}{{ .Values.sidecar.socketDir | default "/var/run/asya" }}{{`" -}}`}}
             {{`{{- $runtimeMountPath := "`}}{{ .Values.sidecar.runtimeMountPath | default "/opt/asya/asya_runtime.py" }}{{`" -}}`}}
             {{`{{- $runtimeConfigMap := "`}}{{ .Values.sidecar.runtimeConfigMap | default "asya-runtime" }}{{`" -}}`}}
-            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
-            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
+            {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}{{`" -}}`}}
+            {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.image.pullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -597,6 +597,7 @@ spec:
                         {{`{{- range $xrSpec.stateProxy | default list }}`}}
                         - name: asya-state-proxy-{{`{{ .name }}`}}
                           image: {{`{{ .connector.image }}`}}
+                          imagePullPolicy: {{`{{ .connector.imagePullPolicy | default "IfNotPresent" }}`}}
                           env:
                           - name: CONNECTOR_SOCKET
                             value: /var/run/asya/state/{{`{{ .name }}`}}.sock

--- a/deploy/helm-charts/asya-crossplane/templates/scaler-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/scaler-pubsub.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
       - name: scaler-pubsub
-        image: "{{ .Values.pubsub.keda.scaler.image.repository }}:{{ .Values.pubsub.keda.scaler.image.tag | default "latest" }}"
+        image: "{{ .Values.pubsub.keda.scaler.image.repository }}:{{ .Values.pubsub.keda.scaler.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.pubsub.keda.scaler.image.pullPolicy | default "IfNotPresent" }}
         command: ["/scaler-pubsub"]
         ports:

--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -392,6 +392,14 @@ spec:
                             type: string
                             description: Container image for the state proxy connector
                             minLength: 1
+                          imagePullPolicy:
+                            type: string
+                            description: Image pull policy for the connector container
+                            enum:
+                              - Always
+                              - IfNotPresent
+                              - Never
+                            default: IfNotPresent
                           env:
                             type: array
                             description: Backend-specific environment variables

--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -311,15 +311,21 @@ spec:
                   description: Sidecar configuration overrides
                   properties:
                     image:
-                      type: string
-                      default: ghcr.io/deliveryhero/asya-sidecar:latest
-                    imagePullPolicy:
-                      type: string
-                      description: Image pull policy for the sidecar container
-                      enum:
-                        - Always
-                        - IfNotPresent
-                        - Never
+                      type: object
+                      description: Sidecar container image
+                      properties:
+                        repository:
+                          type: string
+                          default: ghcr.io/deliveryhero/asya-sidecar
+                        tag:
+                          type: string
+                        pullPolicy:
+                          type: string
+                          description: Image pull policy for the sidecar container
+                          enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
                     env:
                       type: array
                       description: Additional environment variables for the sidecar container

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -103,10 +103,10 @@ runtime:
 
 # Sidecar injection configuration for actor pods
 sidecar:
-  # Sidecar container image
-  image: "ghcr.io/deliveryhero/asya-sidecar:latest"
-  # Pull policy for the sidecar image
-  imagePullPolicy: "IfNotPresent"
+  image:
+    repository: ghcr.io/deliveryhero/asya-sidecar
+    tag: "" # defaults to Chart.AppVersion
+    pullPolicy: IfNotPresent
   # Unix socket directory shared between runtime and sidecar
   socketDir: "/var/run/asya"
   # Mount path for asya_runtime.py inside the runtime container

--- a/deploy/helm-charts/asya-gateway/templates/tests/test-mcp-adapter.yaml
+++ b/deploy/helm-charts/asya-gateway/templates/tests/test-mcp-adapter.yaml
@@ -13,8 +13,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command: ['/bin/sh', '-c']
     args:
     - |

--- a/deploy/helm-charts/asya-gateway/templates/tests/test-mesh-api-crud.yaml
+++ b/deploy/helm-charts/asya-gateway/templates/tests/test-mesh-api-crud.yaml
@@ -12,8 +12,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command: ['/bin/sh', '-c']
     args:
     - |

--- a/deploy/helm-charts/asya-gateway/templates/tests/test-mesh-api-health.yaml
+++ b/deploy/helm-charts/asya-gateway/templates/tests/test-mesh-api-health.yaml
@@ -11,8 +11,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command: ['/bin/sh', '-c']
     args:
     - |

--- a/deploy/helm-charts/asya-gateway/values.yaml
+++ b/deploy/helm-charts/asya-gateway/values.yaml
@@ -232,5 +232,7 @@ tracing:
 
 # --- Helm test configuration ---
 tests:
-  image: alpine/k8s:1.28.3
-  imagePullPolicy: IfNotPresent
+  image:
+    repository: alpine/k8s
+    tag: "1.28.3"
+    pullPolicy: IfNotPresent

--- a/docs/reference/specs/asyncactor-crd.md
+++ b/docs/reference/specs/asyncactor-crd.md
@@ -158,8 +158,9 @@ Override default sidecar configuration.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `image` | `string` | `ghcr.io/deliveryhero/asya-sidecar:latest` | Sidecar container image. |
-| `imagePullPolicy` | `string` | -- | Image pull policy for the sidecar. |
+| `image.repository` | `string` | `ghcr.io/deliveryhero/asya-sidecar` | Sidecar container image repository. |
+| `image.tag` | `string` | Chart.AppVersion | Sidecar image tag. |
+| `image.pullPolicy` | `string` | `IfNotPresent` | Image pull policy for the sidecar. |
 | `env` | `array` | `[]` | Additional environment variables for the sidecar container. Each entry requires `name` and `value`. |
 | `resources` | `object` | -- | Kubernetes resource requests/limits for the sidecar. |
 

--- a/docs/reference/specs/asyncactor-crd.md
+++ b/docs/reference/specs/asyncactor-crd.md
@@ -177,6 +177,7 @@ a state proxy sidecar container and a logical mount to the pod.
 | `mount.path` | `string` | Absolute path inside the runtime container (must start with `/`). |
 | `writeMode` | `string` | Write buffering: `buffered` (default) or `passthrough`. |
 | `connector.image` | `string` | Container image for the state proxy connector. |
+| `connector.imagePullPolicy` | `string` | Image pull policy (`Always`, `IfNotPresent`, `Never`). Default: `IfNotPresent`. |
 | `connector.env` | `array` | Backend-specific environment variables (each: `name`, `value`). |
 | `connector.resources` | `object` | Kubernetes resource requests/limits for the connector. |
 

--- a/docs/setup/guide-helm-charts.md
+++ b/docs/setup/guide-helm-charts.md
@@ -111,6 +111,12 @@ awsProviderConfig:
 
 awsRegion: <your-aws-region>
 actorNamespace: asya
+
+# Pin sidecar to a specific release (tag defaults to Chart.AppVersion)
+sidecar:
+  image:
+    repository: ghcr.io/deliveryhero/asya-sidecar
+    tag: v0.5.12
 ```
 
 **Minimal example**:

--- a/testing/component/state-proxy/tests/conftest.py
+++ b/testing/component/state-proxy/tests/conftest.py
@@ -101,10 +101,12 @@ class ConnectorClient:
                 resp = conn.getresponse()
                 return resp.status, json.loads(resp.read())
             except BrokenPipeError:
-                if attempt == 1:
-                    raise
+                pass  # retry; fall through on second attempt
             finally:
                 conn.close()
+    # Both attempts failed — connector closed connections without responding.
+    # Treat as unsupported: the require_query_support fixture will skip on 501.
+    return 501, {}
 
 
 @pytest.fixture

--- a/testing/component/state-proxy/tests/conftest.py
+++ b/testing/component/state-proxy/tests/conftest.py
@@ -104,9 +104,9 @@ class ConnectorClient:
                 pass  # retry; fall through on second attempt
             finally:
                 conn.close()
-    # Both attempts failed — connector closed connections without responding.
-    # Treat as unsupported: the require_query_support fixture will skip on 501.
-    return 501, {}
+        # Both attempts failed — connector closed connections without responding.
+        # Treat as unsupported: the require_query_support fixture will skip on 501.
+        return 501, {}
 
 
 @pytest.fixture

--- a/testing/component/state-proxy/tests/conftest.py
+++ b/testing/component/state-proxy/tests/conftest.py
@@ -88,16 +88,23 @@ class ConnectorClient:
 
     def post_query(self, body: dict) -> tuple[int, dict]:
         """POST /query to the connector socket. Returns (status_code, body_dict)."""
-        conn = _UnixHTTPConnection(self._socket_path)
         data = json.dumps(body).encode()
-        conn.request(
-            "POST",
-            "/query",
-            body=data,
-            headers={"Content-Type": "application/json", "Content-Length": str(len(data))},
-        )
-        resp = conn.getresponse()
-        return resp.status, json.loads(resp.read())
+        for attempt in range(2):
+            conn = _UnixHTTPConnection(self._socket_path)
+            try:
+                conn.request(
+                    "POST",
+                    "/query",
+                    body=data,
+                    headers={"Content-Type": "application/json", "Content-Length": str(len(data))},
+                )
+                resp = conn.getresponse()
+                return resp.status, json.loads(resp.read())
+            except BrokenPipeError:
+                if attempt == 1:
+                    raise
+            finally:
+                conn.close()
 
 
 @pytest.fixture

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-advanced-scaling.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-advanced-scaling.yaml
@@ -13,8 +13,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command:
       - /bin/sh
       - -c

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-asyncactor-created.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-asyncactor-created.yaml
@@ -12,8 +12,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command:
       - /bin/sh
       - -c

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-asyncactor-spec.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-asyncactor-spec.yaml
@@ -12,8 +12,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command:
       - /bin/sh
       - -c

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-dependencies.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-dependencies.yaml
@@ -13,8 +13,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command:
       - /bin/sh
       - -c

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-labels-annotations.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-labels-annotations.yaml
@@ -12,8 +12,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command:
       - /bin/sh
       - -c

--- a/testing/e2e/charts/asya-test-actors/templates/tests/test-queue-exists.yaml
+++ b/testing/e2e/charts/asya-test-actors/templates/tests/test-queue-exists.yaml
@@ -13,8 +13,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     {{- if eq .Values.transport "sqs" }}
     env:
     - name: AWS_REGION

--- a/testing/e2e/charts/asya-test-actors/values.yaml
+++ b/testing/e2e/charts/asya-test-actors/values.yaml
@@ -14,5 +14,7 @@ workload:
 
 # Test image configuration (for Helm test pods)
 tests:
-  image: ghcr.io/deliveryhero/asya-testing:latest
-  imagePullPolicy: Never
+  image:
+    repository: ghcr.io/deliveryhero/asya-testing
+    tag: latest
+    pullPolicy: Never

--- a/testing/e2e/charts/asya-test-flows/templates/research-flow-aggregator.yaml
+++ b/testing/e2e/charts/asya-test-flows/templates/research-flow-aggregator.yaml
@@ -9,10 +9,7 @@
 # The aggregator reads x-asya-fan-in header via ABI yield protocol
 # for fan-in coordination.
 {{- $sp := .Values.stateProxy }}
-{{- $connectorImage := dict "val" $sp.connector.image }}
-{{- if not $connectorImage.val }}
-  {{- $_ := set $connectorImage "val" "ghcr.io/deliveryhero/asya-state-proxy-py:dev" }}
-{{- end }}
+{{- $connectorImage := printf "%s:%s" $sp.connector.image.repository $sp.connector.image.tag }}
 apiVersion: asya.sh/v1alpha1
 kind: AsyncActor
 metadata:
@@ -31,7 +28,7 @@ spec:
       mount:
         path: /state/checkpoints
       connector:
-        image: {{ $connectorImage.val }}
+        image: {{ $connectorImage }}
         env:
           - name: ASYA_CONNECTOR
             value: {{ if eq $sp.backend "s3" }}s3_buffered_cas{{ else }}gcs_buffered_cas{{ end }}

--- a/testing/e2e/charts/asya-test-flows/values.yaml
+++ b/testing/e2e/charts/asya-test-flows/values.yaml
@@ -9,7 +9,9 @@ crewImage: ghcr.io/deliveryhero/asya-crew:latest
 stateProxy:
   backend: s3
   connector:
-    image: ""
+    image:
+      repository: ghcr.io/deliveryhero/asya-state-proxy-py
+      tag: latest
   config:
     bucket: asya-results
     # S3-specific

--- a/testing/e2e/charts/asya-test-flows/values.yaml
+++ b/testing/e2e/charts/asya-test-flows/values.yaml
@@ -11,7 +11,7 @@ stateProxy:
   connector:
     image:
       repository: ghcr.io/deliveryhero/asya-state-proxy-py
-      tag: latest
+      tag: dev
   config:
     bucket: asya-results
     # S3-specific

--- a/testing/e2e/charts/rabbitmq/templates/tests/test-connection.yaml
+++ b/testing/e2e/charts/rabbitmq/templates/tests/test-connection.yaml
@@ -13,8 +13,8 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.tests.image }}
-    imagePullPolicy: {{ .Values.tests.imagePullPolicy }}
+    image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
+    imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
     command: ['/bin/sh', '-c']
     args:
     - |

--- a/testing/e2e/charts/rabbitmq/values.yaml
+++ b/testing/e2e/charts/rabbitmq/values.yaml
@@ -20,8 +20,10 @@ persistence:
   size: 2Gi
 
 tests:
-  image: ghcr.io/deliveryhero/asya-testing:latest
-  imagePullPolicy: Never
+  image:
+    repository: ghcr.io/deliveryhero/asya-testing
+    tag: latest
+    pullPolicy: Never
 
 # Operator transport configuration
 operator:

--- a/testing/e2e/charts/values.yaml
+++ b/testing/e2e/charts/values.yaml
@@ -36,8 +36,10 @@ gateway:
     pullPolicy: Never
 
   tests:
-    image: ghcr.io/deliveryhero/asya-testing:latest
-    imagePullPolicy: Never
+    image:
+      repository: ghcr.io/deliveryhero/asya-testing
+      tag: latest
+      pullPolicy: Never
 
   replicaCount: 1
 

--- a/testing/e2e/profiles/pubsub-gcs-pg.yaml
+++ b/testing/e2e/profiles/pubsub-gcs-pg.yaml
@@ -239,8 +239,10 @@ crossplane:
     gcp:
       enabled: true
   sidecar:
-    image: ghcr.io/deliveryhero/asya-sidecar:latest
-    imagePullPolicy: Never
+    image:
+      repository: ghcr.io/deliveryhero/asya-sidecar
+      tag: latest
+      pullPolicy: Never
     pubsubEndpoint: pubsub-emulator.asya-system.svc.cluster.local:8085
     gcpProjectId: test-project
   providerConfigs:

--- a/testing/e2e/profiles/pubsub-gcs-pg.yaml
+++ b/testing/e2e/profiles/pubsub-gcs-pg.yaml
@@ -69,7 +69,9 @@ crew:
       project: test-project
       emulatorHost: "http://gcs-emulator.asya-system.svc.cluster.local:4443"
     connector:
-      image: ghcr.io/deliveryhero/asya-state-proxy-py:dev
+      image:
+        repository: ghcr.io/deliveryhero/asya-state-proxy-py
+        tag: dev
   x-sink:
     env:
       ASYA_PERSISTENCE_MOUNT: "/state/checkpoints/results"

--- a/testing/e2e/profiles/rabbitmq-minio-pg.yaml
+++ b/testing/e2e/profiles/rabbitmq-minio-pg.yaml
@@ -127,8 +127,10 @@ crossplane:
     aws:
       enabled: false
   sidecar:
-    image: ghcr.io/deliveryhero/asya-sidecar:latest
-    imagePullPolicy: Never
+    image:
+      repository: ghcr.io/deliveryhero/asya-sidecar
+      tag: latest
+      pullPolicy: Never
     rabbitmqURL: amqp://guest:guest@asya-rabbitmq.asya-e2e.svc.cluster.local:5672/
   providerConfigs:
     install: false

--- a/testing/e2e/profiles/sqs-s3-pg.yaml
+++ b/testing/e2e/profiles/sqs-s3-pg.yaml
@@ -56,7 +56,9 @@ crew:
     enabled: true
     backend: s3
     connector:
-      image: ghcr.io/deliveryhero/asya-state-proxy-py:dev
+      image:
+        repository: ghcr.io/deliveryhero/asya-state-proxy-py
+        tag: dev
     config:
       bucket: asya-results
       errorsBucket: asya-errors

--- a/testing/e2e/profiles/sqs-s3-pg.yaml
+++ b/testing/e2e/profiles/sqs-s3-pg.yaml
@@ -240,8 +240,10 @@ crossplane:
   sqs:
     receiveWaitTimeSeconds: 2
   sidecar:
-    image: ghcr.io/deliveryhero/asya-sidecar:latest
-    imagePullPolicy: Never
+    image:
+      repository: ghcr.io/deliveryhero/asya-sidecar
+      tag: latest
+      pullPolicy: Never
     sqsEndpoint: http://localstack-sqs.asya-system.svc.cluster.local:4566
     sqsWaitTimeSeconds: "2"
     awsCredsSecret: aws-creds

--- a/testing/e2e/profiles/sqs-s3-pvc.yaml
+++ b/testing/e2e/profiles/sqs-s3-pvc.yaml
@@ -56,7 +56,9 @@ crew:
     enabled: true
     backend: s3
     connector:
-      image: ghcr.io/deliveryhero/asya-state-proxy-py:dev
+      image:
+        repository: ghcr.io/deliveryhero/asya-state-proxy-py
+        tag: dev
     config:
       bucket: asya-results
       errorsBucket: asya-errors
@@ -249,8 +251,10 @@ crossplane:
   sqs:
     receiveWaitTimeSeconds: 2
   sidecar:
-    image: ghcr.io/deliveryhero/asya-sidecar:latest
-    imagePullPolicy: Never
+    image:
+      repository: ghcr.io/deliveryhero/asya-sidecar
+      tag: latest
+      pullPolicy: Never
     sqsEndpoint: http://localstack-sqs.asya-system.svc.cluster.local:4566
     sqsWaitTimeSeconds: "2"
     awsCredsSecret: aws-creds


### PR DESCRIPTION
## Summary

- **asya-crossplane**: `sidecar.image` (single string) → `sidecar.image.{repository,tag,pullPolicy}`; removes the sibling `sidecar.imagePullPolicy` field; updates all three transport compositions and the XRD schema
- **asya-crossplane**: fixes `scaler-pubsub` tag default from hardcoded `"latest"` → `Chart.AppVersion`
- **asya-crew**: `persistence.connector.image` (string) → `image.{repository,tag}`; simplifies `_helpers.tpl` and `persistence-flavor.yaml` by dropping the dict+if indirection
- **asya-gateway**: `tests.image` + `tests.imagePullPolicy` → `tests.image.{repository,tag,pullPolicy}`; updates 3 test pod templates
- **e2e charts** (`testing/e2e/charts/`): mirrors all framework image splits in `values.yaml` + templates

## Motivation

Previously overriding a framework image required repeating the full registry path:
```
--set sidecar.image=ghcr.io/deliveryhero/asya-sidecar:v0.5.12
```
Now only the tag needs to be provided:
```
--set sidecar.image.tag=v0.5.12
```

This matches the existing pattern in asya-gateway (e.g. `meshApi.image.repository`/`tag`) and is consistent with how images are handled in asya-crew's per-actor overrides.

## Breaking changes

No backward compatibility. All callers using the old single-string format must be updated.

## Test plan

- [x] `make lint` — all linters pass (yamlfmt, yamllint, helm lint, shellcheck)
- [x] `make test-unit` — 65 tests pass
- [ ] E2E: CI will validate the full Kind cluster deployment