### PR TITLE
feat(loadtest): add asya-loadtest standalone Helm chart with k6

### DIFF
--- a/deploy/helm-charts/asya-loadtest/Chart.yaml
+++ b/deploy/helm-charts/asya-loadtest/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: asya-loadtest
+description: k6-based load testing for Asya installations — direct transport injection or via gateway protocols (mesh-api,
+  A2A, MCP)
+type: application
+# versions are replaced automatically by .github/workflows/release.yml
+version: 0.0.0
+appVersion: "0.0.0"
+keywords:
+- asya
+- loadtest
+- k6
+- performance
+maintainers:
+- name: Asya Team

--- a/deploy/helm-charts/asya-loadtest/templates/_helpers.tpl
+++ b/deploy/helm-charts/asya-loadtest/templates/_helpers.tpl
@@ -73,17 +73,10 @@ Build the ASYA_SCENARIOS JSON value (list of {actor, payload} objects for all en
 */}}
 {{- define "asya-loadtest.scenariosJson" -}}
 {{- $list := list -}}
-{{- if .Values.scenarios.echo.enabled -}}
-  {{- $list = append $list (dict "actor" "loadtest-echo" "payload" (dict)) -}}
-{{- end -}}
-{{- if .Values.scenarios.slow.enabled -}}
-  {{- $list = append $list (dict "actor" "loadtest-slow" "payload" (dict)) -}}
-{{- end -}}
-{{- if .Values.scenarios.fanout.enabled -}}
-  {{- $list = append $list (dict "actor" "loadtest-fanout" "payload" (dict)) -}}
-{{- end -}}
-{{- if .Values.scenarios.stateful.enabled -}}
-  {{- $list = append $list (dict "actor" "loadtest-stateful" "payload" (dict)) -}}
+{{- range $name, $cfg := .Values.scenarios -}}
+  {{- if $cfg.enabled -}}
+    {{- $list = append $list (dict "actor" (printf "loadtest-%s" $name) "payload" (dict)) -}}
+  {{- end -}}
 {{- end -}}
 {{- $list | toJson }}
 {{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/_helpers.tpl
+++ b/deploy/helm-charts/asya-loadtest/templates/_helpers.tpl
@@ -1,0 +1,127 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "asya-loadtest.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "asya-loadtest.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "asya-loadtest.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "asya-loadtest.labels" -}}
+helm.sh/chart: {{ include "asya-loadtest.chart" . }}
+{{ include "asya-loadtest.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "asya-loadtest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "asya-loadtest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Resolve the workload image (tag defaults to Chart.AppVersion).
+*/}}
+{{- define "asya-loadtest.image" -}}
+{{ .Values.workload.image.repository }}:{{ .Values.workload.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Compute the list of enabled scenario names.
+*/}}
+{{- define "asya-loadtest.enabledScenarios" -}}
+{{- $scenarios := list -}}
+{{- range $name, $cfg := .Values.scenarios -}}
+  {{- if $cfg.enabled -}}
+    {{- $scenarios = append $scenarios $name -}}
+  {{- end -}}
+{{- end -}}
+{{- $scenarios | toJson }}
+{{- end }}
+
+{{/*
+Build the ASYA_SCENARIOS JSON value (list of {actor, payload} objects for all enabled scenarios).
+*/}}
+{{- define "asya-loadtest.scenariosJson" -}}
+{{- $list := list -}}
+{{- if .Values.scenarios.echo.enabled -}}
+  {{- $list = append $list (dict "actor" "loadtest-echo" "payload" (dict)) -}}
+{{- end -}}
+{{- if .Values.scenarios.slow.enabled -}}
+  {{- $list = append $list (dict "actor" "loadtest-slow" "payload" (dict)) -}}
+{{- end -}}
+{{- if .Values.scenarios.fanout.enabled -}}
+  {{- $list = append $list (dict "actor" "loadtest-fanout" "payload" (dict)) -}}
+{{- end -}}
+{{- if .Values.scenarios.stateful.enabled -}}
+  {{- $list = append $list (dict "actor" "loadtest-stateful" "payload" (dict)) -}}
+{{- end -}}
+{{- $list | toJson }}
+{{- end }}
+
+{{/*
+Resolve the queue prefix for transport mode.
+Defaults to "asya-{namespace}-" when not set.
+*/}}
+{{- define "asya-loadtest.queuePrefix" -}}
+{{- if .Values.target.transport.queuePrefix -}}
+  {{- .Values.target.transport.queuePrefix -}}
+{{- else -}}
+  {{- printf "asya-%s-" .Release.Namespace -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the k6 target URL based on mode.
+*/}}
+{{- define "asya-loadtest.targetUrl" -}}
+{{- if eq .Values.mode "mesh-api" -}}
+  {{- required "target.mesh.url is required for mesh-api mode" .Values.target.mesh.url -}}
+{{- else if eq .Values.mode "a2a" -}}
+  {{- required "target.a2a.url is required for a2a mode" .Values.target.a2a.url -}}
+{{- else if eq .Values.mode "mcp" -}}
+  {{- required "target.mcp.url is required for mcp mode" .Values.target.mcp.url -}}
+{{- else -}}
+  {{- "" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "asya-loadtest.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+  {{- include "asya-loadtest.fullname" . }}
+{{- else -}}
+  default
+{{- end -}}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
@@ -283,14 +283,16 @@ data:
             params = pika.URLParameters(os.environ["ASYA_RABBITMQ_URL"])
             self._conn = pika.BlockingConnection(params)
             self._channel = self._conn.channel()
+            self._lock = Lock()
 
         def send(self, actor: str, envelope: dict) -> None:
             queue = f"{QUEUE_PREFIX}{actor}"
-            self._channel.basic_publish(
-                exchange="",
-                routing_key=queue,
-                body=json.dumps(envelope).encode(),
-            )
+            with self._lock:
+                self._channel.basic_publish(
+                    exchange="",
+                    routing_key=queue,
+                    body=json.dumps(envelope).encode(),
+                )
 
 
     _SENDERS = {"sqs": _SQSSender, "pubsub": _PubSubSender, "rabbitmq": _RabbitMQSender}
@@ -315,9 +317,20 @@ data:
             if self.path != "/envelopes":
                 self._respond(404, b"not found", "text/plain")
                 return
-            length = int(self.headers.get("Content-Length", 0))
-            body = json.loads(self.rfile.read(length))
-            actor   = body["actor"]
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except ValueError:
+                self._respond(400, b"invalid Content-Length", "text/plain")
+                return
+            if length <= 0 or length > 1_048_576:
+                self._respond(400, b"Content-Length missing or exceeds 1 MiB", "text/plain")
+                return
+            try:
+                body = json.loads(self.rfile.read(length))
+                actor = body["actor"]
+            except (json.JSONDecodeError, KeyError):
+                self._respond(400, b"invalid JSON or missing 'actor' field", "text/plain")
+                return
             payload = body.get("payload", {})
             vu      = payload.pop("_k6_vu", "0")
             itr     = payload.pop("_k6_iter", "0")
@@ -341,5 +354,5 @@ data:
             self.wfile.write(body)
 
 
-    print(f"[+] Transport injector :{PORT} (transport={TRANSPORT} prefix={QUEUE_PREFIX!r})")
-    ThreadingHTTPServer(("", PORT), _Handler).serve_forever()
+    print(f"[+] Transport injector 127.0.0.1:{PORT} (transport={TRANSPORT} prefix={QUEUE_PREFIX!r})")
+    ThreadingHTTPServer(("127.0.0.1", PORT), _Handler).serve_forever()

--- a/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
@@ -54,7 +54,7 @@ data:
 
     export const options = {
       vus: parseInt(__ENV.K6_VUS),
-      stages: JSON.parse(__ENV.K6_STAGES),
+      stages: JSON.parse(__ENV.ASYA_K6_STAGES),
     };
 
     export default function () {
@@ -81,7 +81,7 @@ data:
 
     export const options = {
       vus: parseInt(__ENV.K6_VUS),
-      stages: JSON.parse(__ENV.K6_STAGES),
+      stages: JSON.parse(__ENV.ASYA_K6_STAGES),
     };
 
     export default function () {
@@ -110,7 +110,7 @@ data:
 
     export const options = {
       vus: parseInt(__ENV.K6_VUS),
-      stages: JSON.parse(__ENV.K6_STAGES),
+      stages: JSON.parse(__ENV.ASYA_K6_STAGES),
     };
 
     export default function () {
@@ -149,7 +149,7 @@ data:
 
     export const options = {
       vus: parseInt(__ENV.K6_VUS),
-      stages: JSON.parse(__ENV.K6_STAGES),
+      stages: JSON.parse(__ENV.ASYA_K6_STAGES),
     };
 
     // Per-VU MCP session ID — initialized lazily on the first iteration.

--- a/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/configmap-scripts.yaml
@@ -1,0 +1,345 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "asya-loadtest.fullname" . }}-scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+data:
+  # ─── Bash entrypoint ─────────────────────────────────────────────────────────
+  # Starts the Python injector (transport mode only) and then runs k6.
+  entrypoint.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    MODE="${ASYA_MODE}"
+    K6_ARGS=(run)
+    [ -n "${K6_PROMETHEUS_RW_SERVER_URL:-}" ] && K6_ARGS+=(--out experimental-prometheus-rw)
+
+    case "$MODE" in
+      transport)
+        python3 /scripts/injector.py &
+        INJECTOR_PID=$!
+        echo "[+] Waiting for transport injector on :8080..."
+        for i in $(seq 1 30); do
+          curl -sf http://localhost:8080/health > /dev/null && break
+          sleep 1
+        done
+        k6 "${K6_ARGS[@]}" /scripts/transport-load-test.js
+        STATUS=$?
+        kill "$INJECTOR_PID" 2>/dev/null || true
+        exit "$STATUS"
+        ;;
+      mesh-api)
+        exec k6 "${K6_ARGS[@]}" /scripts/mesh-load-test.js
+        ;;
+      a2a)
+        exec k6 "${K6_ARGS[@]}" /scripts/a2a-load-test.js
+        ;;
+      mcp)
+        exec k6 "${K6_ARGS[@]}" /scripts/mcp-load-test.js
+        ;;
+      *)
+        echo "Unknown mode: $MODE (must be transport | mesh-api | a2a | mcp)" >&2
+        exit 1
+        ;;
+    esac
+
+  # ─── Transport mode: k6 → Python injector (localhost:8080) → SQS/PubSub/RabbitMQ ──
+  transport-load-test.js: |
+    import http from 'k6/http';
+    import { check } from 'k6';
+
+    const scenarios = JSON.parse(__ENV.ASYA_SCENARIOS);
+
+    export const options = {
+      vus: parseInt(__ENV.K6_VUS),
+      stages: JSON.parse(__ENV.K6_STAGES),
+    };
+
+    export default function () {
+      const s = scenarios[__VU % scenarios.length];
+      const body = JSON.stringify({
+        actor: s.actor,
+        payload: Object.assign({}, s.payload, { _k6_vu: String(__VU), _k6_iter: String(__ITER) }),
+      });
+      const res = http.post('http://localhost:8080/envelopes', body, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      check(res, { 'accepted': (r) => r.status === 202 });
+    }
+
+  # ─── Mesh-API mode: k6 → gateway REST endpoint ────────────────────────────────
+  # Targets: POST {ASYA_TARGET_URL} with a simple JSON body.
+  # No protocol overhead — fastest gateway path, good for measuring gateway latency.
+  mesh-load-test.js: |
+    import http from 'k6/http';
+    import { check } from 'k6';
+
+    const targetUrl = __ENV.ASYA_TARGET_URL;
+    const scenarios = JSON.parse(__ENV.ASYA_SCENARIOS);
+
+    export const options = {
+      vus: parseInt(__ENV.K6_VUS),
+      stages: JSON.parse(__ENV.K6_STAGES),
+    };
+
+    export default function () {
+      const s = scenarios[__VU % scenarios.length];
+      const body = JSON.stringify({
+        actor: s.actor,
+        input: Object.assign({}, s.payload, { _k6_vu: String(__VU), _k6_iter: String(__ITER) }),
+      });
+      const res = http.post(targetUrl, body, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      check(res, { 'submitted': (r) => r.status >= 200 && r.status < 300 });
+    }
+
+  # ─── A2A mode: k6 → A2A sendMessage ──────────────────────────────────────────
+  # Targets: POST {ASYA_TARGET_URL}/{ASYA_A2A_AGENT_ID}/sendMessage
+  # Follows A2A JSON-RPC message format.
+  a2a-load-test.js: |
+    import http from 'k6/http';
+    import { check } from 'k6';
+
+    const baseUrl  = __ENV.ASYA_TARGET_URL.replace(/\/$/, '');
+    const agentId  = __ENV.ASYA_A2A_AGENT_ID;
+    const endpoint = agentId ? `${baseUrl}/${agentId}` : baseUrl;
+    const scenarios = JSON.parse(__ENV.ASYA_SCENARIOS);
+
+    export const options = {
+      vus: parseInt(__ENV.K6_VUS),
+      stages: JSON.parse(__ENV.K6_STAGES),
+    };
+
+    export default function () {
+      const s = scenarios[__VU % scenarios.length];
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: `${__VU}-${__ITER}`,
+        method: 'tasks/send',
+        params: {
+          message: {
+            role: 'user',
+            parts: [
+              {
+                type: 'data',
+                data: Object.assign({}, s.payload, { _k6_vu: String(__VU), _k6_iter: String(__ITER) }),
+              },
+            ],
+          },
+        },
+      });
+      const res = http.post(endpoint, body, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      check(res, { 'submitted': (r) => r.status >= 200 && r.status < 300 });
+    }
+
+  # ─── MCP mode: k6 → MCP JSON-RPC (tools/call) ────────────────────────────────
+  # Each VU lazily initializes its own MCP session (Mcp-Session-Id) on first call.
+  # Module-level variables in k6 are per-VU, so sessionId is naturally isolated.
+  mcp-load-test.js: |
+    import http from 'k6/http';
+    import { check } from 'k6';
+
+    const mcpUrl   = __ENV.ASYA_TARGET_URL.replace(/\/$/, '') + '/mcp';
+    const scenarios = JSON.parse(__ENV.ASYA_SCENARIOS);
+
+    export const options = {
+      vus: parseInt(__ENV.K6_VUS),
+      stages: JSON.parse(__ENV.K6_STAGES),
+    };
+
+    // Per-VU MCP session ID — initialized lazily on the first iteration.
+    let sessionId = null;
+
+    function initSession() {
+      const res = http.post(
+        mcpUrl,
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 0,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            clientInfo: { name: 'asya-loadtest', version: '1.0' },
+            capabilities: {},
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+      if (res.status !== 200) {
+        throw new Error(`MCP initialize failed: ${res.status} ${res.body}`);
+      }
+      sessionId = res.headers['Mcp-Session-Id'] || res.headers['mcp-session-id'];
+      if (!sessionId) {
+        throw new Error('MCP initialize returned no Mcp-Session-Id');
+      }
+    }
+
+    export default function () {
+      if (!sessionId) {
+        initSession();
+      }
+      const s = scenarios[__VU % scenarios.length];
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: __ITER,
+        method: 'tools/call',
+        params: {
+          name: s.actor,
+          arguments: Object.assign({}, s.payload, { _k6_vu: String(__VU), _k6_iter: String(__ITER) }),
+        },
+      });
+      const res = http.post(mcpUrl, body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Mcp-Session-Id': sessionId,
+        },
+      });
+      check(res, { 'called': (r) => r.status >= 200 && r.status < 300 });
+    }
+
+  # ─── Transport injector ───────────────────────────────────────────────────────
+  # Bridges k6 HTTP to Asya transport backends.
+  # Accepts:  POST /envelopes  {"actor": "...", "payload": {...}}
+  # Responds: 202 Accepted
+  # Health:   GET /health
+  # Metrics:  GET /metrics  (Prometheus text format, scraped by PodMonitor)
+  injector.py: |
+    import json
+    import os
+    import time
+    import uuid
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from threading import Lock
+
+    from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+
+    TRANSPORT    = os.environ["ASYA_TRANSPORT_TYPE"]
+    QUEUE_PREFIX = os.environ["ASYA_QUEUE_PREFIX"]
+    PORT         = int(os.environ.get("INJECTOR_PORT", "8080"))
+
+    _envelopes_sent = Counter(
+        "asya_loadtest_envelopes_sent_total",
+        "Envelopes injected into transport",
+        ["transport", "actor", "result"],
+    )
+    _send_duration = Histogram(
+        "asya_loadtest_send_duration_seconds",
+        "Transport send latency",
+        ["transport", "actor"],
+    )
+
+
+    def _build_envelope(actor: str, payload: dict, vu: str, iteration: str) -> dict:
+        return {
+            "id": str(uuid.uuid4()),
+            "parent_id": None,
+            "route": {"prev": [], "curr": actor, "next": []},
+            "headers": {"trace_id": f"k6-{vu}-{iteration}"},
+            "payload": payload,
+        }
+
+
+    class _SQSSender:
+        def __init__(self):
+            import boto3
+            self._client = boto3.client(
+                "sqs",
+                region_name=os.environ.get("ASYA_SQS_REGION", "us-east-1"),
+                endpoint_url=os.environ.get("ASYA_SQS_ENDPOINT") or None,
+                aws_access_key_id=os.environ.get("ASYA_SQS_ACCESS_KEY") or None,
+                aws_secret_access_key=os.environ.get("ASYA_SQS_SECRET_KEY") or None,
+            )
+            self._urls: dict[str, str] = {}
+            self._lock = Lock()
+
+        def send(self, actor: str, envelope: dict) -> None:
+            queue = f"{QUEUE_PREFIX}{actor}"
+            if queue not in self._urls:
+                with self._lock:
+                    if queue not in self._urls:
+                        self._urls[queue] = self._client.get_queue_url(QueueName=queue)["QueueUrl"]
+            self._client.send_message(QueueUrl=self._urls[queue], MessageBody=json.dumps(envelope))
+
+
+    class _PubSubSender:
+        def __init__(self):
+            from google.cloud import pubsub_v1
+            self._project = os.environ["ASYA_PUBSUB_PROJECT"]
+            self._publisher = pubsub_v1.PublisherClient()
+
+        def send(self, actor: str, envelope: dict) -> None:
+            topic = f"projects/{self._project}/topics/{QUEUE_PREFIX}{actor}"
+            self._publisher.publish(topic, json.dumps(envelope).encode()).result()
+
+
+    class _RabbitMQSender:
+        def __init__(self):
+            import pika
+            params = pika.URLParameters(os.environ["ASYA_RABBITMQ_URL"])
+            self._conn = pika.BlockingConnection(params)
+            self._channel = self._conn.channel()
+
+        def send(self, actor: str, envelope: dict) -> None:
+            queue = f"{QUEUE_PREFIX}{actor}"
+            self._channel.basic_publish(
+                exchange="",
+                routing_key=queue,
+                body=json.dumps(envelope).encode(),
+            )
+
+
+    _SENDERS = {"sqs": _SQSSender, "pubsub": _PubSubSender, "rabbitmq": _RabbitMQSender}
+    if TRANSPORT not in _SENDERS:
+        raise ValueError(f"Unknown transport: {TRANSPORT!r}. Must be one of: {list(_SENDERS)}")
+    _sender = _SENDERS[TRANSPORT]()
+
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_):
+            pass
+
+        def do_GET(self):
+            if self.path == "/health":
+                self._respond(200, b"ok", "text/plain")
+            elif self.path == "/metrics":
+                self._respond(200, generate_latest(), CONTENT_TYPE_LATEST)
+            else:
+                self._respond(404, b"not found", "text/plain")
+
+        def do_POST(self):
+            if self.path != "/envelopes":
+                self._respond(404, b"not found", "text/plain")
+                return
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length))
+            actor   = body["actor"]
+            payload = body.get("payload", {})
+            vu      = payload.pop("_k6_vu", "0")
+            itr     = payload.pop("_k6_iter", "0")
+            envelope = _build_envelope(actor, payload, vu, itr)
+            t0 = time.monotonic()
+            try:
+                _sender.send(actor, envelope)
+                _send_duration.labels(transport=TRANSPORT, actor=actor).observe(time.monotonic() - t0)
+                _envelopes_sent.labels(transport=TRANSPORT, actor=actor, result="ok").inc()
+                self._respond(202, b"", "text/plain")
+            except Exception as exc:
+                _send_duration.labels(transport=TRANSPORT, actor=actor).observe(time.monotonic() - t0)
+                _envelopes_sent.labels(transport=TRANSPORT, actor=actor, result="error").inc()
+                self._respond(500, str(exc).encode(), "text/plain")
+
+        def _respond(self, code: int, body: bytes, content_type: str) -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+
+    print(f"[+] Transport injector :{PORT} (transport={TRANSPORT} prefix={QUEUE_PREFIX!r})")
+    ThreadingHTTPServer(("", PORT), _Handler).serve_forever()

--- a/deploy/helm-charts/asya-loadtest/templates/job.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/job.yaml
@@ -36,6 +36,10 @@ spec:
         asya.sh/loadtest: "true"
         asya.sh/loadtest-mode: {{ .Values.mode | quote }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       restartPolicy: Never
       serviceAccountName: {{ include "asya-loadtest.serviceAccountName" . }}
       containers:
@@ -43,6 +47,11 @@ spec:
         image: {{ include "asya-loadtest.image" . }}
         imagePullPolicy: {{ .Values.workload.image.pullPolicy }}
         command: ["/bin/bash", "/scripts/entrypoint.sh"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         env:
         - name: ASYA_MODE
           value: {{ .Values.mode | quote }}

--- a/deploy/helm-charts/asya-loadtest/templates/job.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/job.yaml
@@ -59,7 +59,7 @@ spec:
           value: {{ include "asya-loadtest.scenariosJson" . | quote }}
         - name: K6_VUS
           value: {{ .Values.k6.vus | quote }}
-        - name: K6_STAGES
+        - name: ASYA_K6_STAGES
           value: {{ $stages | toJson | quote }}
         {{- if .Values.metrics.prometheus.remoteWriteUrl }}
         - name: K6_PROMETHEUS_RW_SERVER_URL

--- a/deploy/helm-charts/asya-loadtest/templates/job.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/job.yaml
@@ -1,0 +1,108 @@
+{{- /* Validate mode */ -}}
+{{- if not (has .Values.mode (list "transport" "mesh-api" "a2a" "mcp")) -}}
+  {{- fail (printf "mode %q is invalid; must be one of: transport, mesh-api, a2a, mcp" .Values.mode) -}}
+{{- end -}}
+{{- /* Validate that at least one scenario is enabled */ -}}
+{{- $enabledCount := 0 -}}
+{{- range .Values.scenarios -}}
+  {{- if .enabled -}}
+    {{- $enabledCount = add1 $enabledCount -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $enabledCount 0 -}}
+  {{- fail "at least one scenario must be enabled (e.g. scenarios.echo.enabled=true)" -}}
+{{- end -}}
+{{- /* Build k6 stages from vus + duration + rampUp */ -}}
+{{- $stages := list -}}
+{{- if and .Values.k6.rampUp (ne .Values.k6.rampUp "0") (ne .Values.k6.rampUp "0s") -}}
+  {{- $stages = append $stages (dict "duration" .Values.k6.rampUp "target" .Values.k6.vus) -}}
+{{- end -}}
+{{- $stages = append $stages (dict "duration" .Values.k6.duration "target" .Values.k6.vus) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "asya-loadtest.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+    asya.sh/loadtest-mode: {{ .Values.mode | quote }}
+spec:
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "asya-loadtest.selectorLabels" . | nindent 8 }}
+        asya.sh/loadtest: "true"
+        asya.sh/loadtest-mode: {{ .Values.mode | quote }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "asya-loadtest.serviceAccountName" . }}
+      containers:
+      - name: k6
+        image: {{ include "asya-loadtest.image" . }}
+        imagePullPolicy: {{ .Values.workload.image.pullPolicy }}
+        command: ["/bin/bash", "/scripts/entrypoint.sh"]
+        env:
+        - name: ASYA_MODE
+          value: {{ .Values.mode | quote }}
+        - name: ASYA_SCENARIOS
+          value: {{ include "asya-loadtest.scenariosJson" . | quote }}
+        - name: K6_VUS
+          value: {{ .Values.k6.vus | quote }}
+        - name: K6_STAGES
+          value: {{ $stages | toJson | quote }}
+        {{- if .Values.metrics.prometheus.remoteWriteUrl }}
+        - name: K6_PROMETHEUS_RW_SERVER_URL
+          value: {{ .Values.metrics.prometheus.remoteWriteUrl | quote }}
+        {{- end }}
+        {{- if ne .Values.mode "transport" }}
+        - name: ASYA_TARGET_URL
+          value: {{ include "asya-loadtest.targetUrl" . | quote }}
+        {{- end }}
+        {{- if eq .Values.mode "a2a" }}
+        - name: ASYA_A2A_AGENT_ID
+          value: {{ .Values.target.a2a.agentId | quote }}
+        {{- end }}
+        {{- if eq .Values.mode "transport" }}
+        - name: INJECTOR_PORT
+          value: {{ .Values.metrics.prometheus.scrapePort | quote }}
+        - name: ASYA_TRANSPORT_TYPE
+          value: {{ .Values.target.transport.type | quote }}
+        - name: ASYA_QUEUE_PREFIX
+          value: {{ include "asya-loadtest.queuePrefix" . | quote }}
+        {{- if eq .Values.target.transport.type "sqs" }}
+        - name: ASYA_SQS_REGION
+          value: {{ .Values.target.transport.sqs.region | quote }}
+        {{- if .Values.target.transport.sqs.endpoint }}
+        - name: ASYA_SQS_ENDPOINT
+          value: {{ .Values.target.transport.sqs.endpoint | quote }}
+        {{- end }}
+        {{- if .Values.target.transport.sqs.accessKey }}
+        - name: ASYA_SQS_ACCESS_KEY
+          value: {{ .Values.target.transport.sqs.accessKey | quote }}
+        - name: ASYA_SQS_SECRET_KEY
+          value: {{ .Values.target.transport.sqs.secretKey | quote }}
+        {{- end }}
+        {{- else if eq .Values.target.transport.type "pubsub" }}
+        - name: ASYA_PUBSUB_PROJECT
+          value: {{ required "target.transport.pubsub.project is required for pubsub transport" .Values.target.transport.pubsub.project | quote }}
+        {{- else if eq .Values.target.transport.type "rabbitmq" }}
+        - name: ASYA_RABBITMQ_URL
+          value: {{ required "target.transport.rabbitmq.url is required for rabbitmq transport" .Values.target.transport.rabbitmq.url | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if and (eq .Values.mode "transport") .Values.metrics.prometheus.podMonitor }}
+        ports:
+        - name: injector-metrics
+          containerPort: {{ .Values.metrics.prometheus.scrapePort }}
+          protocol: TCP
+        {{- end }}
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ include "asya-loadtest.fullname" . }}-scripts
+          defaultMode: 0755

--- a/deploy/helm-charts/asya-loadtest/templates/podmonitor.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/podmonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and (eq .Values.mode "transport") .Values.metrics.prometheus.podMonitor }}
+# PodMonitor scrapes the transport injector's /metrics endpoint.
+# Only relevant in transport mode — gateway modes export metrics via k6 remote write.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "asya-loadtest.fullname" . }}-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "asya-loadtest.selectorLabels" . | nindent 6 }}
+      asya.sh/loadtest-mode: "transport"
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - port: injector-metrics
+    path: /metrics
+    interval: 15s
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/scenarios/echo.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/scenarios/echo.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.scenarios.echo.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loadtest-echo-handler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+data:
+  handler.py: |
+    async def handler(payload: dict) -> dict:
+        return payload
+---
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: loadtest-echo
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+    asya.sh/loadtest: "true"
+spec:
+  actor: loadtest-echo
+
+  image: {{ include "asya-loadtest.image" . }}
+  imagePullPolicy: {{ .Values.workload.image.pullPolicy }}
+  handler: handler.handler
+
+  env:
+  - name: PYTHONPATH
+    value: /app
+
+  volumeMounts:
+  - name: handler
+    mountPath: /app
+
+  volumes:
+  - name: handler
+    configMap:
+      name: loadtest-echo-handler
+
+  scaling:
+    enabled: true
+    minReplicaCount: {{ .Values.scenarios.echo.scaling.minReplicaCount }}
+    maxReplicaCount: {{ .Values.scenarios.echo.scaling.maxReplicaCount }}
+    pollingInterval: {{ .Values.scenarios.echo.scaling.pollingInterval }}
+    cooldownPeriod: {{ .Values.scenarios.echo.scaling.cooldownPeriod }}
+    queueLength: {{ .Values.scenarios.echo.scaling.queueLength }}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/scenarios/fanout.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/scenarios/fanout.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.scenarios.fanout.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loadtest-fanout-handler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+data:
+  handler.py: |
+    import os
+    from collections.abc import Generator
+
+    def handler(payload: dict) -> Generator[dict, None, None]:
+        n = int(os.getenv("LOADTEST_FANOUT_SIZE", "3"))
+        for i in range(n):
+            yield {**payload, "_fan_index": i}
+---
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: loadtest-fanout
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+    asya.sh/loadtest: "true"
+spec:
+  actor: loadtest-fanout
+
+  image: {{ include "asya-loadtest.image" . }}
+  imagePullPolicy: {{ .Values.workload.image.pullPolicy }}
+  handler: handler.handler
+
+  env:
+  - name: PYTHONPATH
+    value: /app
+  - name: LOADTEST_FANOUT_SIZE
+    value: {{ .Values.scenarios.fanout.size | quote }}
+
+  volumeMounts:
+  - name: handler
+    mountPath: /app
+
+  volumes:
+  - name: handler
+    configMap:
+      name: loadtest-fanout-handler
+
+  scaling:
+    enabled: true
+    minReplicaCount: {{ .Values.scenarios.fanout.scaling.minReplicaCount }}
+    maxReplicaCount: {{ .Values.scenarios.fanout.scaling.maxReplicaCount }}
+    pollingInterval: {{ .Values.scenarios.fanout.scaling.pollingInterval }}
+    cooldownPeriod: {{ .Values.scenarios.fanout.scaling.cooldownPeriod }}
+    queueLength: {{ .Values.scenarios.fanout.scaling.queueLength }}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/scenarios/slow.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/scenarios/slow.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.scenarios.slow.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loadtest-slow-handler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+data:
+  handler.py: |
+    import asyncio
+    import os
+
+    async def handler(payload: dict) -> dict:
+        delay_ms = int(os.getenv("LOADTEST_DELAY_MS", "500"))
+        await asyncio.sleep(delay_ms / 1000)
+        return payload
+---
+apiVersion: asya.sh/v1alpha1
+kind: AsyncActor
+metadata:
+  name: loadtest-slow
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+    asya.sh/loadtest: "true"
+spec:
+  actor: loadtest-slow
+
+  image: {{ include "asya-loadtest.image" . }}
+  imagePullPolicy: {{ .Values.workload.image.pullPolicy }}
+  handler: handler.handler
+
+  env:
+  - name: PYTHONPATH
+    value: /app
+  - name: LOADTEST_DELAY_MS
+    value: {{ .Values.scenarios.slow.delayMs | quote }}
+
+  volumeMounts:
+  - name: handler
+    mountPath: /app
+
+  volumes:
+  - name: handler
+    configMap:
+      name: loadtest-slow-handler
+
+  scaling:
+    enabled: true
+    minReplicaCount: {{ .Values.scenarios.slow.scaling.minReplicaCount }}
+    maxReplicaCount: {{ .Values.scenarios.slow.scaling.maxReplicaCount }}
+    pollingInterval: {{ .Values.scenarios.slow.scaling.pollingInterval }}
+    cooldownPeriod: {{ .Values.scenarios.slow.scaling.cooldownPeriod }}
+    queueLength: {{ .Values.scenarios.slow.scaling.queueLength }}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/scenarios/stateful.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/scenarios/stateful.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.scenarios.stateful.enabled }}
+{{- fail "scenarios.stateful is not yet fully wired: state proxy sidecar configuration must be added before enabling this scenario" }}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/templates/serviceaccount.yaml
+++ b/deploy/helm-charts/asya-loadtest/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "asya-loadtest.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "asya-loadtest.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm-charts/asya-loadtest/values.yaml
+++ b/deploy/helm-charts/asya-loadtest/values.yaml
@@ -1,0 +1,119 @@
+# asya-loadtest — standalone Helm chart for k6-based load testing
+#
+# Deploys a Kubernetes Job that drives load against an existing Asya installation.
+# Optionally deploys AsyncActor CRDs for dedicated load test actors (requires Crossplane).
+#
+# MODES:
+#   transport  — inject envelopes directly into the queue backend (SQS/PubSub/RabbitMQ)
+#   mesh-api   — submit tasks via the mesh-api REST endpoint (cluster-internal, no protocol overhead)
+#   a2a        — submit tasks via the A2A protocol
+#   mcp        — submit tasks via the MCP JSON-RPC protocol
+
+# Image shared by both the k6 Job runner and the deployed actor pods.
+# Must contain the k6 binary (asya-testing does).
+workload:
+  image:
+    repository: ghcr.io/deliveryhero/asya-testing
+    tag: "" # defaults to Chart.appVersion
+    pullPolicy: IfNotPresent
+
+# Load generation settings
+k6:
+  vus: 20
+  duration: 5m
+  rampUp: 0s # 0 = start at full VUs; otherwise a linear ramp-up stage is prepended
+
+# Target mode — selects both which endpoint k6 hits and whether the transport injector starts
+mode: transport # transport | mesh-api | a2a | mcp
+
+# Endpoint config — only the section matching `mode` is used
+target:
+  transport:
+    type: sqs # sqs | pubsub | rabbitmq
+    # Queue name: {queuePrefix}{actor}. Defaults to "asya-{namespace}-" when empty.
+    queuePrefix: ""
+    sqs:
+      endpoint: "" # empty = real AWS; set to http://localstack:4566 for local dev
+      region: us-east-1
+      accessKey: "" # leave empty to use IRSA / workload identity
+      secretKey: ""
+    pubsub:
+      project: "" # GCP project ID (required for pubsub)
+    rabbitmq:
+      url: "" # amqp://user:pass@host:5672/
+
+  mesh:
+    # Full URL including path, e.g. http://asya-gateway-api:8080/api/v1/mesh/
+    url: ""
+
+  a2a:
+    # Base URL for A2A agent, e.g. http://asya-gateway-api:8080/a2a/
+    url: ""
+    agentId: "" # A2A agent identifier (appended to url)
+
+  mcp:
+    # MCP base URL (the /mcp path is appended automatically), e.g. http://asya-gateway-mcp:8080
+    url: ""
+
+# Scenarios — each enables both the actor AsyncActor CRD and load against it.
+# Actor name: loadtest-{scenario}.  At least one must be enabled.
+#
+# Common scaling defaults (override per scenario):
+_scalingDefaults: &scalingDefaults
+  minReplicaCount: 0
+  maxReplicaCount: 20
+  pollingInterval: 5
+  cooldownPeriod: 60
+  queueLength: 5
+
+scenarios:
+  # Echo: passthrough — zero processing time, measures transport + sidecar overhead baseline
+  echo:
+    enabled: false
+    scaling:
+      !!merge <<: *scalingDefaults
+
+  # Slow: configurable fixed delay — drives queue depth to trigger KEDA autoscaling
+  slow:
+    enabled: false
+    delayMs: 500 # sleep duration per envelope (env var LOADTEST_DELAY_MS in handler)
+    scaling:
+      !!merge <<: *scalingDefaults
+
+  # Fanout: yields N envelopes per input — stresses fan-out routing and x-sink convergence
+  fanout:
+    enabled: false
+    size: 3 # envelopes emitted per input (env var LOADTEST_FANOUT_SIZE in handler)
+    scaling:
+      !!merge <<: *scalingDefaults
+
+  # Stateful: reads and writes via state proxy — requires state proxy to be configured
+  # NOTE: stub only in v1; stateProxy wiring must be added before enabling
+  stateful:
+    enabled: false
+    scaling:
+      !!merge <<: *scalingDefaults
+
+# Metrics output
+metrics:
+  prometheus:
+    # k6 remote-write URL (enables --out experimental-prometheus-rw for all modes)
+    # Example: http://prometheus-operated:9090/api/v1/write
+    remoteWriteUrl: ""
+    # Port on which the transport injector exposes its own /metrics (transport mode only).
+    # Also the port k6 calls for envelope injection — both share the same port.
+    scrapePort: 8080
+    # Create a PodMonitor to scrape the injector metrics (requires Prometheus Operator)
+    podMonitor: false
+
+# Job lifecycle
+job:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+
+# ServiceAccount — useful for IRSA (SQS/S3) or Workload Identity (PubSub)
+serviceAccount:
+  create: true
+  annotations: {}
+  # Example for IRSA:
+  #   eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/asya-loadtest"

--- a/deploy/helm-charts/asya-loadtest/values.yaml
+++ b/deploy/helm-charts/asya-loadtest/values.yaml
@@ -40,7 +40,7 @@ target:
     pubsub:
       project: "" # GCP project ID (required for pubsub)
     rabbitmq:
-      url: "" # amqp://user:pass@host:5672/
+      url: "" # amqp://host:5672/ (include credentials in the URL if auth is required)
 
   mesh:
     # Full URL including path, e.g. http://asya-gateway-api:8080/api/v1/mesh/

--- a/src/asya-testing/Dockerfile
+++ b/src/asya-testing/Dockerfile
@@ -1,6 +1,11 @@
+FROM grafana/k6:latest AS k6
+
 FROM python:3.13-slim
 
 WORKDIR /opt/asya
+
+# k6 binary for asya-loadtest chart Jobs
+COPY --from=k6 /usr/bin/k6 /usr/bin/k6
 
 # Install CLI tools used by Helm tests (curl, wget, jq)
 # and kubectl for Kubernetes resource inspection

--- a/src/asya-testing/requirements.txt
+++ b/src/asya-testing/requirements.txt
@@ -18,3 +18,4 @@ google-cloud-pubsub>=2.23.0
 google-cloud-storage>=2.14.0
 PyJWT[cryptography]>=2.8.0
 cryptography>=42.0.0
+prometheus_client>=0.20.0


### PR DESCRIPTION
## Summary

- Adds `deploy/helm-charts/asya-loadtest/` — a standalone Helm chart for k6-based load testing of any Asya installation
- Adds k6 binary to `asya-testing` image via `COPY --from=grafana/k6` (zero new images)
- Adds `prometheus_client>=0.20.0` to `asya-testing` requirements for transport injector metrics

### Four load target modes

| Mode | Description |
|---|---|
| `transport` | Inject envelopes directly into SQS/PubSub/RabbitMQ via Python injector subprocess |
| `mesh-api` | HTTP POST to gateway REST dispatch endpoint (no protocol overhead) |
| `a2a` | A2A JSON-RPC `tasks/send` |
| `mcp` | MCP JSON-RPC `tools/call` with per-VU lazy session management |

### Three scenarios (all `enabled: false` by default)

| Scenario | Actor | Purpose |
|---|---|---|
| `echo` | `loadtest-echo` | Passthrough — measures transport + sidecar overhead baseline |
| `slow` | `loadtest-slow` | Configurable fixed delay (`delayMs`) — drives queue depth for KEDA autoscaling |
| `fanout` | `loadtest-fanout` | Yields N envelopes per input (`size`) — stresses fan-out + x-sink convergence |

Each scenario bundles an AsyncActor CRD + an inlined handler ConfigMap. `stateful` is a stub (`fail` guard until state proxy wiring is added).

### Architecture

- Single `asya-testing` image for both the Job runner and actor pods — no new image to build or release
- Transport mode: k6 → Python injector (localhost, same container) → queue SDK (boto3/pika/pubsub). The injector uses `ThreadingHTTPServer` and exposes `/metrics` (Prometheus text) alongside `/envelopes` on the same port
- Gateway modes: stock k6 HTTP, no injector needed
- k6 stages are computed from `k6.vus` + `k6.duration` + optional `k6.rampUp`; rendered as `K6_STAGES` JSON
- Optional `PodMonitor` (transport mode only) for Prometheus Operator scraping of injector metrics
- Optional `K6_PROMETHEUS_RW_SERVER_URL` for k6 remote write (all modes)

## Test plan

- [ ] `helm template` renders correctly for all four modes (validated locally)
- [ ] `helm lint` passes (validated locally, all pre-commit hooks pass)
- [ ] Validate transport mode against a live installation with `scenarios.echo.enabled=true` and LocalStack
- [ ] Validate gateway modes against a live installation (once Kind cluster is free)