### PR TITLE
feat(tracing): add HTTP/protobuf OTLP transport to all Go components

### DIFF
--- a/deploy/helm-charts/asya-crew/templates/checkpoint-s3.yaml
+++ b/deploy/helm-charts/asya-crew/templates/checkpoint-s3.yaml
@@ -19,9 +19,14 @@ spec:
     - {{ include "asya-crew.persistence.flavorName" . }}
   {{- end }}
 
-  {{- if .Values.tracing.endpoint }}
+  {{- if or .Values.tracing.endpoint .Values.tracing.protocol }}
   tracing:
+    {{- if .Values.tracing.endpoint }}
     endpoint: {{ .Values.tracing.endpoint | quote }}
+    {{- end }}
+    {{- if .Values.tracing.protocol }}
+    protocol: {{ .Values.tracing.protocol | quote }}
+    {{- end }}
   {{- end }}
 
   {{- with $checkpointS3.sidecar }}

--- a/deploy/helm-charts/asya-crew/templates/pause.yaml
+++ b/deploy/helm-charts/asya-crew/templates/pause.yaml
@@ -14,9 +14,14 @@ metadata:
 spec:
   actor: {{ $pause.name }}
 
-  {{- if .Values.tracing.endpoint }}
+  {{- if or .Values.tracing.endpoint .Values.tracing.protocol }}
   tracing:
+    {{- if .Values.tracing.endpoint }}
     endpoint: {{ .Values.tracing.endpoint | quote }}
+    {{- end }}
+    {{- if .Values.tracing.protocol }}
+    protocol: {{ .Values.tracing.protocol | quote }}
+    {{- end }}
   {{- end }}
 
   {{- with $pause.sidecar }}

--- a/deploy/helm-charts/asya-crew/templates/resume.yaml
+++ b/deploy/helm-charts/asya-crew/templates/resume.yaml
@@ -14,9 +14,14 @@ metadata:
 spec:
   actor: {{ $resume.name }}
 
-  {{- if .Values.tracing.endpoint }}
+  {{- if or .Values.tracing.endpoint .Values.tracing.protocol }}
   tracing:
+    {{- if .Values.tracing.endpoint }}
     endpoint: {{ .Values.tracing.endpoint | quote }}
+    {{- end }}
+    {{- if .Values.tracing.protocol }}
+    protocol: {{ .Values.tracing.protocol | quote }}
+    {{- end }}
   {{- end }}
 
   {{- with $resume.sidecar }}

--- a/deploy/helm-charts/asya-crew/templates/sink.yaml
+++ b/deploy/helm-charts/asya-crew/templates/sink.yaml
@@ -19,9 +19,14 @@ spec:
     {{- include "asya-crew.persistence.stateProxy" . | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.tracing.endpoint }}
+  {{- if or .Values.tracing.endpoint .Values.tracing.protocol }}
   tracing:
+    {{- if .Values.tracing.endpoint }}
     endpoint: {{ .Values.tracing.endpoint | quote }}
+    {{- end }}
+    {{- if .Values.tracing.protocol }}
+    protocol: {{ .Values.tracing.protocol | quote }}
+    {{- end }}
   {{- end }}
 
   {{- with $sink.sidecar }}

--- a/deploy/helm-charts/asya-crew/templates/sump.yaml
+++ b/deploy/helm-charts/asya-crew/templates/sump.yaml
@@ -19,9 +19,14 @@ spec:
     {{- include "asya-crew.persistence.stateProxy" (dict "Values" .Values "bucket" .Values.persistence.config.errorsBucket) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.tracing.endpoint }}
+  {{- if or .Values.tracing.endpoint .Values.tracing.protocol }}
   tracing:
+    {{- if .Values.tracing.endpoint }}
     endpoint: {{ .Values.tracing.endpoint | quote }}
+    {{- end }}
+    {{- if .Values.tracing.protocol }}
+    protocol: {{ .Values.tracing.protocol | quote }}
+    {{- end }}
   {{- end }}
 
   {{- with $sump.sidecar }}

--- a/deploy/helm-charts/asya-crew/values.yaml
+++ b/deploy/helm-charts/asya-crew/values.yaml
@@ -13,7 +13,10 @@ image:
 
 # Distributed tracing configuration
 tracing:
+  # endpoint format depends on protocol: grpc → host:4317, http → http://host:4318
   endpoint: ""
+  # protocol: leave empty for gRPC (default), set "http" for HTTP/protobuf
+  protocol: ""
 
 # X-sink actor configuration
 # First layer of two-layer termination: reports final status to gateway, routes to hooks

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -348,6 +348,7 @@ spec:
             {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
             {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
+            {{`{{- $tracingProtocol := "`}}{{ .Values.sidecar.tracingProtocol }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}
             {{`{{- $scalingEnabled := true -}}`}}
@@ -532,6 +533,13 @@ spec:
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
                             value: {{`{{ $tracingEndpoint }}`}}
+                          {{`{{- end }}`}}
+                          {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
+                          {{`{{- else if ne $tracingProtocol "" }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`{{ $tracingProtocol }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-pubsub.yaml
@@ -532,14 +532,14 @@ spec:
                             value: {{`"{{ $xrSpec.tracing.endpoint }}"`}}
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                            value: {{`{{ $tracingEndpoint }}`}}
+                            value: {{`{{ $tracingEndpoint | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
                             value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
                           {{`{{- else if ne $tracingProtocol "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
-                            value: {{`{{ $tracingProtocol }}`}}
+                            value: {{`{{ $tracingProtocol | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -252,6 +252,7 @@ spec:
             {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
             {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
+            {{`{{- $tracingProtocol := "`}}{{ .Values.sidecar.tracingProtocol }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}
             {{`{{- $scalingEnabled := true -}}`}}
@@ -432,6 +433,13 @@ spec:
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
                             value: {{`{{ $tracingEndpoint }}`}}
+                          {{`{{- end }}`}}
+                          {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
+                          {{`{{- else if ne $tracingProtocol "" }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`{{ $tracingProtocol }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-rabbitmq.yaml
@@ -432,14 +432,14 @@ spec:
                             value: {{`"{{ $xrSpec.tracing.endpoint }}"`}}
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                            value: {{`{{ $tracingEndpoint }}`}}
+                            value: {{`{{ $tracingEndpoint | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
                             value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
                           {{`{{- else if ne $tracingProtocol "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
-                            value: {{`{{ $tracingProtocol }}`}}
+                            value: {{`{{ $tracingProtocol | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -364,6 +364,7 @@ spec:
             {{`{{- $sidecarImage := "`}}{{ .Values.sidecar.image | default "ghcr.io/deliveryhero/asya-sidecar:latest" }}{{`" -}}`}}
             {{`{{- $sidecarImagePullPolicy := "`}}{{ .Values.sidecar.imagePullPolicy | default "IfNotPresent" }}{{`" -}}`}}
             {{`{{- $tracingEndpoint := "`}}{{ .Values.sidecar.tracingEndpoint }}{{`" -}}`}}
+            {{`{{- $tracingProtocol := "`}}{{ .Values.sidecar.tracingProtocol }}{{`" -}}`}}
             {{`{{- $socketPath := printf "%s/asya-runtime.sock" $socketDir -}}`}}
             {{`{{- $isSystemActor := or (eq $actorName "x-sink") (eq $actorName "x-sump") (eq $actorName "happy-end") (eq $actorName "error-end") -}}`}}
             {{`{{- $queueURL := "" -}}`}}
@@ -569,6 +570,13 @@ spec:
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
                             value: {{`{{ $tracingEndpoint }}`}}
+                          {{`{{- end }}`}}
+                          {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
+                          {{`{{- else if ne $tracingProtocol "" }}`}}
+                          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                            value: {{`{{ $tracingProtocol }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/composition-sqs.yaml
@@ -569,14 +569,14 @@ spec:
                             value: {{`"{{ $xrSpec.tracing.endpoint }}"`}}
                           {{`{{- else if ne $tracingEndpoint "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                            value: {{`{{ $tracingEndpoint }}`}}
+                            value: {{`{{ $tracingEndpoint | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if and $xrSpec.tracing $xrSpec.tracing.protocol }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
                             value: {{`"{{ $xrSpec.tracing.protocol }}"`}}
                           {{`{{- else if ne $tracingProtocol "" }}`}}
                           - name: OTEL_EXPORTER_OTLP_PROTOCOL
-                            value: {{`{{ $tracingProtocol }}`}}
+                            value: {{`{{ $tracingProtocol | quote }}`}}
                           {{`{{- end }}`}}
                           {{`{{- if $xrSpec.resiliency }}`}}
                           {{`{{- if $xrSpec.resiliency.policies }}`}}

--- a/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
+++ b/deploy/helm-charts/asya-crossplane/templates/xrd-asyncactor.yaml
@@ -343,7 +343,10 @@ spec:
                   properties:
                     endpoint:
                       type: string
-                      description: "Creates OTEL_EXPORTER_OTLP_ENDPOINT env var in the sidecar (e.g. tempo:4317)"
+                      description: "OTLP endpoint. grpc (default): host:4317 — e.g. tempo:4317. http: full URL — e.g. http://tempo:4318"
+                    protocol:
+                      type: string
+                      description: "OTLP transport protocol. Leave empty for gRPC (default). Set 'http' for HTTP/protobuf."
 
                 stateProxy:
                   type: array

--- a/deploy/helm-charts/asya-crossplane/values.yaml
+++ b/deploy/helm-charts/asya-crossplane/values.yaml
@@ -134,7 +134,11 @@ sidecar:
   # GCP project ID for Pub/Sub access (cluster-wide)
   gcpProjectId: ""
   # OTLP endpoint for distributed tracing (leave empty to disable)
+  # grpc (default): host:port — e.g. tempo:4317
+  # http:           full URL  — e.g. http://tempo:4318
   tracingEndpoint: ""
+  # OTLP transport protocol. Leave empty for gRPC (default). Set "http" for HTTP/protobuf.
+  tracingProtocol: ""
 
 # KEDA authentication configuration (SQS)
 keda:

--- a/deploy/helm-charts/asya-gateway/templates/deployment.yaml
+++ b/deploy/helm-charts/asya-gateway/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ .Values.tracing.endpoint | quote }}
         {{- end }}
+        {{- if .Values.tracing.protocol }}
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: {{ .Values.tracing.protocol | quote }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "asya-gateway.fullname" . }}

--- a/deploy/helm-charts/asya-gateway/values.yaml
+++ b/deploy/helm-charts/asya-gateway/values.yaml
@@ -225,7 +225,13 @@ affinity: {}
 
 # --- Tracing ---
 tracing:
+  # endpoint format depends on protocol:
+  #   grpc (default): bare host:port  — e.g. tempo:4317
+  #   http:           full URL        — e.g. http://tempo:4318
   endpoint: ""
+  # protocol selects the OTLP transport. Leave empty to use gRPC (default).
+  # Set to "http" to use HTTP/protobuf (OTLP port 4318).
+  protocol: ""
   # serviceName is sent as OTEL_SERVICE_NAME. Default "asya-gateway" maintains
   # backward compatibility with existing Tempo/Grafana dashboards.
   serviceName: "asya-gateway"

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -215,7 +215,8 @@ Uses the same queue transport env vars as asya-gateway (`ASYA_QUEUE_TRANSPORT`,
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP exporter endpoint | _(unset)_ |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint. Format depends on protocol: gRPC → `host:4317`; HTTP → `http://host:4318` | _(unset)_ |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport protocol: `""` / `"grpc"` → gRPC (default); `"http"` → HTTP/protobuf | _(unset — gRPC)_ |
 
 ---
 

--- a/docs/setup/ops-observability.md
+++ b/docs/setup/ops-observability.md
@@ -236,10 +236,34 @@ Exposed via controller-runtime:
 
 ### Configuration
 
-Set `OTEL_EXPORTER_OTLP_ENDPOINT` on sidecar and gateway to enable tracing:
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` on sidecar and gateway to enable tracing. Both gRPC
+(default) and HTTP/protobuf transports are supported, selected by `OTEL_EXPORTER_OTLP_PROTOCOL`.
 
-- **Sidecar**: Set via `spec.tracing.endpoint` in AsyncActor CR
-- **Gateway**: Set via `tracing.endpoint` in gateway Helm values
+The endpoint format depends on the protocol:
+- **gRPC** (default, port 4317): bare `host:port` — e.g. `tempo:4317`
+- **HTTP/protobuf** (port 4318): full URL — e.g. `http://tempo:4318`
+
+**Sidecar (per-actor)**:
+```yaml
+spec:
+  tracing:
+    endpoint: "tempo:4317"      # or "http://tempo:4318" for HTTP
+    protocol: ""                # omit or "grpc" for gRPC; "http" for HTTP/protobuf
+```
+
+**Gateway** (Helm values):
+```yaml
+tracing:
+  endpoint: "tempo:4317"
+  protocol: ""                  # omit or "grpc" for gRPC; "http" for HTTP/protobuf
+```
+
+**Crossplane chart** (cluster-wide sidecar default):
+```yaml
+sidecar:
+  tracingEndpoint: "tempo:4317"
+  tracingProtocol: ""           # omit or "grpc" for gRPC; "http" for HTTP/protobuf
+```
 
 ### Playground Setup
 

--- a/src/asya-gateway/go.mod
+++ b/src/asya-gateway/go.mod
@@ -59,6 +59,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/src/asya-gateway/go.sum
+++ b/src/asya-gateway/go.sum
@@ -164,6 +164,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bT
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=

--- a/src/asya-gateway/internal/tracing/tracing.go
+++ b/src/asya-gateway/internal/tracing/tracing.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -16,8 +18,10 @@ import (
 
 // Init initializes the global OpenTelemetry tracer provider.
 // If endpoint is empty, a no-op tracer provider is set (tracing disabled).
-// Otherwise, creates an OTLP gRPC exporter, resource with service.name and service.namespace,
-// and a BatchSpanProcessor. Returns a shutdown function to flush and close the provider.
+// Otherwise, creates an OTLP exporter using the protocol selected by
+// OTEL_EXPORTER_OTLP_PROTOCOL ("http" → HTTP/protobuf, anything else → gRPC).
+// gRPC expects bare host:port; HTTP expects a full URL (http://host:4318).
+// Returns a shutdown function to flush and close the provider.
 func Init(endpoint, serviceName, namespace string) (func(context.Context) error, error) {
 	if endpoint == "" {
 		slog.Info("OTEL tracing disabled (no endpoint configured)")
@@ -25,19 +29,30 @@ func Init(endpoint, serviceName, namespace string) (func(context.Context) error,
 		return func(context.Context) error { return nil }, nil
 	}
 
-	slog.Info("Initializing OTEL tracing", "endpoint", endpoint, "service", serviceName, "namespace", namespace)
+	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	slog.Info("Initializing OTEL tracing", "endpoint", endpoint, "protocol", protocol, "service", serviceName, "namespace", namespace)
 
-	// Create OTLP gRPC exporter (insecure for in-cluster communication)
-	exporter, err := otlptracegrpc.New(
-		context.Background(),
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithInsecure(),
+	var (
+		exporter sdktrace.SpanExporter
+		err      error
 	)
+	if protocol == "http" {
+		exporter, err = otlptracehttp.New(
+			context.Background(),
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithInsecure(),
+		)
+	} else {
+		exporter, err = otlptracegrpc.New(
+			context.Background(),
+			otlptracegrpc.WithEndpoint(endpoint),
+			otlptracegrpc.WithInsecure(),
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
 	}
 
-	// Create resource with service.name and service.namespace
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
@@ -49,21 +64,16 @@ func Init(endpoint, serviceName, namespace string) (func(context.Context) error,
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	// Create tracer provider with batch span processor
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
 	)
 
-	// Set as global tracer provider
 	otel.SetTracerProvider(tp)
-
-	// Set W3C TraceContext propagator
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	slog.Info("OTEL tracing initialized successfully")
 
-	// Return shutdown function
 	return tp.Shutdown, nil
 }
 

--- a/src/asya-gateway/internal/tracing/tracing_test.go
+++ b/src/asya-gateway/internal/tracing/tracing_test.go
@@ -86,3 +86,35 @@ func TestInit_WithEndpoint(t *testing.T) {
 		t.Error("SpanContext should be valid for real provider")
 	}
 }
+
+func TestInit_HTTPProtocol(t *testing.T) {
+	oldProvider := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(oldProvider) })
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http")
+
+	// HTTP endpoint uses full URL format (host:port without scheme is also accepted
+	// by otlptracehttp.WithEndpoint — it will not actually connect in unit tests)
+	shutdown, err := Init("localhost:4318", "test-service", "test-ns")
+	if err != nil {
+		t.Fatalf("Init with HTTP protocol should not error: %v", err)
+	}
+	defer shutdown(context.Background())
+
+	tp := otel.GetTracerProvider()
+	if _, ok := tp.(noop.TracerProvider); ok {
+		t.Error("Expected real TracerProvider when endpoint is provided, got noop")
+	}
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	if !span.IsRecording() {
+		t.Error("Span should be recording with HTTP protocol")
+	}
+
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		t.Error("SpanContext should be valid for real provider")
+	}
+}

--- a/src/asya-sidecar/go.mod
+++ b/src/asya-sidecar/go.mod
@@ -58,6 +58,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/src/asya-sidecar/go.sum
+++ b/src/asya-sidecar/go.sum
@@ -164,6 +164,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bT
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=

--- a/src/asya-sidecar/internal/tracing/tracing.go
+++ b/src/asya-sidecar/internal/tracing/tracing.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -16,8 +18,10 @@ import (
 
 // Init initializes the global OpenTelemetry tracer provider.
 // If endpoint is empty, a no-op tracer provider is set (tracing disabled).
-// Otherwise, creates an OTLP gRPC exporter, resource with service.name and service.namespace,
-// and a BatchSpanProcessor. Returns a shutdown function to flush and close the provider.
+// Otherwise, creates an OTLP exporter using the protocol selected by
+// OTEL_EXPORTER_OTLP_PROTOCOL ("http" → HTTP/protobuf, anything else → gRPC).
+// gRPC expects bare host:port; HTTP expects a full URL (http://host:4318).
+// Returns a shutdown function to flush and close the provider.
 func Init(endpoint, serviceName, namespace string) (func(context.Context) error, error) {
 	if endpoint == "" {
 		slog.Info("OTEL tracing disabled (no endpoint configured)")
@@ -25,19 +29,30 @@ func Init(endpoint, serviceName, namespace string) (func(context.Context) error,
 		return func(context.Context) error { return nil }, nil
 	}
 
-	slog.Info("Initializing OTEL tracing", "endpoint", endpoint, "service", serviceName, "namespace", namespace)
+	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	slog.Info("Initializing OTEL tracing", "endpoint", endpoint, "protocol", protocol, "service", serviceName, "namespace", namespace)
 
-	// Create OTLP gRPC exporter (insecure for in-cluster communication)
-	exporter, err := otlptracegrpc.New(
-		context.Background(),
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithInsecure(),
+	var (
+		exporter sdktrace.SpanExporter
+		err      error
 	)
+	if protocol == "http" {
+		exporter, err = otlptracehttp.New(
+			context.Background(),
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithInsecure(),
+		)
+	} else {
+		exporter, err = otlptracegrpc.New(
+			context.Background(),
+			otlptracegrpc.WithEndpoint(endpoint),
+			otlptracegrpc.WithInsecure(),
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
 	}
 
-	// Create resource with service.name and service.namespace
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
@@ -49,21 +64,16 @@ func Init(endpoint, serviceName, namespace string) (func(context.Context) error,
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	// Create tracer provider with batch span processor
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
 	)
 
-	// Set as global tracer provider
 	otel.SetTracerProvider(tp)
-
-	// Set W3C TraceContext propagator
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	slog.Info("OTEL tracing initialized successfully")
 
-	// Return shutdown function
 	return tp.Shutdown, nil
 }
 

--- a/src/asya-sidecar/internal/tracing/tracing_test.go
+++ b/src/asya-sidecar/internal/tracing/tracing_test.go
@@ -75,6 +75,34 @@ func TestInit_RecordingWhenEndpointProvided(t *testing.T) {
 	}
 }
 
+func TestInit_HTTPProtocol(t *testing.T) {
+	resetGlobalTracer(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http")
+
+	// otlptracehttp.WithEndpoint accepts bare host:port and will not actually connect
+	shutdown, err := Init("localhost:4318", "test-service", "test-namespace")
+	if err != nil {
+		t.Fatalf("Init with HTTP protocol should not error, got: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("Init should return non-nil shutdown function")
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	tp := otel.GetTracerProvider()
+	if _, ok := tp.(*sdktrace.TracerProvider); !ok {
+		t.Errorf("Expected *sdktrace.TracerProvider with HTTP protocol, got %T", tp)
+	}
+
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	if !span.IsRecording() {
+		t.Error("Expected recording span when HTTP endpoint is provided")
+	}
+}
+
 func TestInit_ServiceNameAndNamespace(t *testing.T) {
 	resetGlobalTracer(t)
 

--- a/testing/integration/sidecar/go.mod
+++ b/testing/integration/sidecar/go.mod
@@ -56,6 +56,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect

--- a/testing/integration/sidecar/go.sum
+++ b/testing/integration/sidecar/go.sum
@@ -164,6 +164,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bT
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=


### PR DESCRIPTION
## Summary

- **Go code** (`asya-gateway`, `asya-sidecar`): `Init()` now reads `OTEL_EXPORTER_OTLP_PROTOCOL` and branches between `otlptracegrpc` (default) and `otlptracehttp`. Both use insecure connections, matching in-cluster Tempo setup.
- **Helm charts**: `tracing.protocol` field added to `asya-gateway` and `asya-crew`; `sidecar.tracingProtocol` added to `asya-crossplane`. All 3 compositions emit `OTEL_EXPORTER_OTLP_PROTOCOL` into sidecar containers.
- **XRD**: `spec.tracing.protocol` field added to `AsyncActor` CRD.
- **Tests**: `TestInit_HTTPProtocol` added to both `tracing_test.go` suites.
- **Docs**: `docs/reference/env-vars.md` and `docs/setup/ops-observability.md` updated with endpoint format guidance for both protocols.

## Endpoint format

The protocol determines the expected endpoint format (both use insecure/plain connections):

| Protocol | Env var value | Endpoint format | Port |
|----------|--------------|-----------------|------|
| gRPC (default) | `""` or `"grpc"` | `host:4317` | 4317 |
| HTTP/protobuf | `"http"` | `host:4318` | 4318 |

## Python components

`asya-runtime` and `asya-crew` (Python) use `opentelemetry-sdk` which already respects `OTEL_EXPORTER_OTLP_PROTOCOL` from the environment automatically — no Python changes needed.

## Test plan

- [x] `go test ./internal/tracing/...` passes in both `asya-gateway` and `asya-sidecar`
- [x] `TestInit_HTTPProtocol` verifies HTTP path creates a recording provider
- [x] `golangci-lint` passes for both components
- [x] `helm lint` passes for all charts
- [x] `yamllint` / `yamlfmt` passes