### PR TITLE
fix(examples): pin litellm>=1.83.7 (CVE-2026-42208) and drop unused google extra in agentic

### DIFF
--- a/examples/end-to-end/monorepo/src/agentic/requirements.txt
+++ b/examples/end-to-end/monorepo/src/agentic/requirements.txt
@@ -1,2 +1,2 @@
-litellm[google]
+litellm>=1.83.7
 tenacity

--- a/examples/end-to-end/monorepo/src/text-improver/requirements.txt
+++ b/examples/end-to-end/monorepo/src/text-improver/requirements.txt
@@ -1,2 +1,2 @@
-litellm[google]
+litellm[google]>=1.83.7
 tenacity


### PR DESCRIPTION
## Summary

- Pin `litellm>=1.83.7` in both `agentic/` and `text-improver/` example requirements to remediate **CVE-2026-42208** (pre-auth SQL injection in the LiteLLM proxy server, all versions <1.83.7).
- Drop the unused `[google]` extra from `agentic/requirements.txt`.

## Why drop `[google]` from agentic?

The agentic example actors only call:
- `claude-sonnet-4-6` (Anthropic)
- `gpt-4o` (OpenAI)
- `mock` (LiteLLM's built-in mock provider)

No Vertex AI / Gemini calls anywhere. The `[google]` extra pulls in `google-cloud-aiplatform` and related Google Cloud SDKs (~80 MB) that the actors never touch.

`text-improver/` keeps `[google]` — all four of its actors call `vertex_ai/gemini-2.0-flash`, which requires the Google extras at runtime.

## Note on the CVE

CVE-2026-42208 lives in `litellm.proxy.*` (the standalone LiteLLM proxy server). Both example projects only use LiteLLM as a **client library** (`litellm.acompletion(...)`) — they never start the proxy server. The exploitable surface is therefore zero. Pinning is still the correct hygiene because Wiz and other scanners flag any litellm install in the vulnerable version range, regardless of how it's used.

## Test plan

- [ ] CI green
- [ ] `pip install -r examples/end-to-end/monorepo/src/agentic/requirements.txt` resolves to litellm 1.83.7+ without `google-cloud-aiplatform`
- [ ] `pip install -r examples/end-to-end/monorepo/src/text-improver/requirements.txt` resolves to litellm[google] 1.83.7+
- [ ] Compile-flows pre-commit hook still passes for both example projects

Refs aint `9tb9v`.