### PR TITLE
docs: use colorful logo in README and docs header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="left">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/website/img/logo_colored_with_borders.png">
-    <img src="./docs/website/img/logo_black_w_borders.png" alt="Asya" width="120"/>
-  </picture>
+  <img src="./docs/website/img/logo_colored_with_borders.png" alt="Asya" width="120"/>
   &nbsp;&nbsp;
   <img src="./docs/website/img/dh-logo.png" alt="Delivery Hero" width="120"/>
 </p>

--- a/docs/website/stylesheets/extra.css
+++ b/docs/website/stylesheets/extra.css
@@ -504,7 +504,7 @@ table td code {
 .dark .codehilite .il,
 .dark .highlight .il { color: #79c0ff }
 
-/* Top-left logo — gray at rest, colored on hover */
+/* Top-left logo — colorful and always visible */
 .asya-home-link {
   margin-right: 4px;
 }
@@ -525,47 +525,12 @@ table td code {
   width: 20px;
   object-fit: contain;
   transition: opacity 0.2s ease;
+  opacity: 1;
 }
 
-.asya-logo-gray {
-  opacity: 0.6;
-}
-
-.asya-logo-light {
-  display: none;
-}
-
-.asya-logo-color {
-  display: none;
-}
-
-/* Light mode: gray at rest, colored on hover */
-.asya-home-link:hover .asya-logo-gray {
-  display: none;
-}
-
-.asya-home-link:hover .asya-logo-color {
-  display: block;
-  opacity: 0.6;
-}
-
-/* Dark mode: light gray at rest, colored on hover */
-.dark .asya-logo-gray {
-  display: none;
-}
-
-.dark .asya-logo-light {
-  display: block;
-  opacity: 0.6;
-}
-
-.dark .asya-home-link:hover .asya-logo-light {
-  display: none;
-}
-
-.dark .asya-home-link:hover .asya-logo-color {
-  display: block;
-  opacity: 0.5;
+/* Slightly dim on hover for feedback */
+.asya-home-link:hover .asya-home-logo {
+  opacity: 0.8;
 }
 
 /* KubeCon banner */

--- a/docs/website/templates/header.html
+++ b/docs/website/templates/header.html
@@ -72,8 +72,6 @@
             <!-- Logo — links to asya.sh landing page -->
             <a class="asya-home-link hidden lg:flex items-center justify-center rounded-md size-8 transition-all hover:bg-accent dark:hover:bg-accent/50"
                 href="https://asya.sh" title="asya.sh">
-                <img class="asya-home-logo asya-logo-gray" src="{{ 'website/img/logo_gray.png' | url }}" alt="Asya" />
-                <img class="asya-home-logo asya-logo-light" src="{{ 'website/img/logo_light_gray.png' | url }}" alt="Asya" />
                 <img class="asya-home-logo asya-logo-color" src="{{ 'website/img/logo_colored_with_borders.png' | url }}" alt="Asya" />
             </a>
 

--- a/docs/website/templates/header.html
+++ b/docs/website/templates/header.html
@@ -72,7 +72,7 @@
             <!-- Logo — links to asya.sh landing page -->
             <a class="asya-home-link hidden lg:flex items-center justify-center rounded-md size-8 transition-all hover:bg-accent dark:hover:bg-accent/50"
                 href="https://asya.sh" title="asya.sh">
-                <img class="asya-home-logo asya-logo-color" src="{{ 'website/img/logo_colored_with_borders.png' | url }}" alt="Asya" />
+                <img class="asya-home-logo" src="{{ 'website/img/logo_colored_with_borders.png' | url }}" alt="Asya" />
             </a>
 
             <!-- Asya Docs button -->


### PR DESCRIPTION
## Summary
- Replace black/white logo with colorful Asya logo in README
- Update docs header to use colorful logo consistently across all themes
- Simplify logo CSS by removing gray variant switching logic

## Changes
- **README.md**: Changed from black/white picture element to colorful logo
- **docs/website/templates/header.html**: Use only the colorful logo variant
- **docs/website/stylesheets/extra.css**: Remove theme-specific gray logo rules, keep colorful logo with hover opacity change

The gray and black/white logo files remain in the repository but are no longer referenced in public-facing docs or landing pages.