### PR TITLE
chore: bump minimum Python version to 3.10

### DIFF
--- a/src/asya-lab/pyproject.toml
+++ b/src/asya-lab/pyproject.toml
@@ -2,7 +2,7 @@
 name = "asya-lab"
 version = "0.1.0"
 description = "Developer tools for debugging and operating Asya framework"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["click>=8.1", "requests", "tqdm", "pyyaml", "omegaconf>=2.3.0"]
 
 [project.optional-dependencies]

--- a/src/asya-testing/pyproject.toml
+++ b/src/asya-testing/pyproject.toml
@@ -2,7 +2,7 @@
 name = "asya-testing"
 version = "0.1.0"
 description = "Shared test library for Asya framework tests"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["dependencies"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary

Dependabot no longer supports Python 3.9. Updated `requires-python` constraint in `asya-testing` and `asya-lab` packages to 3.10, aligning with project's runtime (Python 3.13) and existing code patterns that require 3.10+.

## Changes

- `src/asya-testing/pyproject.toml`: `requires-python >= 3.9` → `>= 3.10`
- `src/asya-lab/pyproject.toml`: `requires-python >= 3.9` → `>= 3.10`

Resolves Dependabot PR #495 warning.