### PR TITLE
feat(asya-lab): migrate flow→gateway registration to split gateway

### DIFF
--- a/docs/setup/guide-gateway.md
+++ b/docs/setup/guide-gateway.md
@@ -216,16 +216,20 @@ The gateway acts as its own authorization server, issuing HMAC-SHA256 JWTs.
 | `mcp:invoke` | Call tools, send messages |
 | `mcp:read` | List tools, read task state |
 
-## Tool Registration
+## Flow Registration
 
-The gateway reads tool definitions from `*.yaml` files in `/etc/asya/flows/`. It polls
-every 10 seconds (configurable via `ASYA_CONFIG_POLL_INTERVAL`) and hot-reloads without
-a pod restart.
+A flow is exposed to the gateway as an **A2A agent** and/or an **MCP tool**. Each protocol
+has its own registry ConfigMap, hot-reloaded without a pod restart (polled every 10s,
+configurable via `ASYA_CONFIG_POLL_INTERVAL`; or force a reload — see below):
 
-The directory is populated from ConfigMaps via a projected volume. Two sources:
+| Protocol | ConfigMap | Data key | Adapter mount |
+|---|---|---|---|
+| A2A | `asya-gateway-a2a-agents` | `agents.yaml` (`agents:` list) | `ASYA_A2A_CONFIG_DIR` |
+| MCP | `asya-gateway-mcp-tools` | `tools.yaml` (`tools:` list) | `ASYA_MCP_CONFIG_DIR` |
 
-1. **Helm-managed** (`asya-gateway-flows` CM) — seeded at deploy time via `exposedFlows`
-2. **Per-flow CMs** — deployed alongside actors by `asya k apply`, auto-registered
+Seed entries at deploy time via the chart's `a2aAgents` / `mcpTools` values; add or update them
+later with the CLI (below) or by editing the ConfigMap directly. Each entry's `actor` field is
+the flow's entrypoint actor (`start-<flow>` for compiled flows).
 
 ### Using the CLI (recommended)
 
@@ -242,8 +246,9 @@ asya expose text-flow -d "Analyze text" --mcp --a2a --context dev
 asya k apply text-flow --context dev
 ```
 
-`asya k apply` detects the per-flow ConfigMap and patches the gateway deployment
-to include it as a projected volume source. No Helm upgrade needed.
+`asya expose` (or `asya patch --gateway`) writes a local `flow-expose.yaml` intent; `asya k apply`
+upserts it (keyed by `name`) into the `asya-gateway-a2a-agents` / `asya-gateway-mcp-tools` ConfigMaps,
+which the gateway hot-reloads. No deployment patch and no Helm upgrade needed.
 
 To disable for an environment:
 
@@ -254,124 +259,60 @@ asya k apply text-flow --context dev
 
 ### Using Helm Values
 
-Seed flows at deploy time via `exposedFlows`, or list per-flow CMs via `flowConfigMaps`:
+Seed agents/tools at deploy time via the chart's `a2aAgents` and `mcpTools` values:
 
 ```yaml
 # values.yaml
-exposedFlows:
+a2aAgents:
 - name: echo
-  entrypoint: echo-actor
-  description: Echo handler
-  mcp: {}
-
-flowConfigMaps:
-- asya-flow-text-flow-config
-- asya-flow-greet-flow-config
-```
-
-### Manual ConfigMap
-
-For custom setups, create a flows ConfigMap directly:
-
-### Step 1: Create flows.yaml
-
-```yaml
-flows:
-- name: echo
-  entrypoint: echo-actor
   description: Echo back the input with a greeting
-  mcp:
-    inputSchema:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name to greet
-      required: [name]
+  actor: echo-actor          # the flow entrypoint actor
+  timeout: 60
+  streaming: true
+  skills:
+  - {id: echo, name: echo, description: Echo handler}
+  inputModes: [text/plain, application/json]
+  outputModes: [text/plain, application/json]
+
+mcpTools:
+- name: echo
+  description: Echo back the input with a greeting
+  actor: echo-actor
+  timeout: 60
+  inputSchema:
+    type: object
+    properties:
+      name: {type: string, description: Name to greet}
+    required: [name]
 ```
 
-### Multi-Actor Pipeline
+### Entry Fields
 
-```yaml
-flows:
-- name: text-analysis
-  entrypoint: preprocess
-  route_next: [inference, postprocess]
-  description: Analyze text through a preprocessing, inference, and postprocessing pipeline
-  timeout: 120
-  mcp:
-    inputSchema:
-      type: object
-      properties:
-        text:
-          type: string
-          description: Text to analyze
-      required: [text]
-```
-
-### Expose as Both MCP and A2A
-
-```yaml
-flows:
-- name: text-analysis
-  entrypoint: preprocess
-  route_next: [inference, postprocess]
-  description: Analyze text
-  mcp:
-    inputSchema:
-      type: object
-      properties:
-        text:
-          type: string
-      required: [text]
-  a2a: {}
-```
-
-### Flow Configuration Fields
+**A2A agent** (`agents.yaml`):
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | yes | Unique flow name; becomes the MCP tool name and A2A skill name |
-| `entrypoint` | yes | First actor in the pipeline (actor name, not queue name) |
-| `route_next` | no | Ordered list of subsequent actors |
-| `description` | no | Human-readable description surfaced in tool/skill listings |
+| `name` | yes | Unique agent name; the A2A endpoint is `/a2a/<name>` |
+| `actor` | yes | Flow entrypoint actor (`start-<flow>` for compiled flows) |
+| `description` | yes | Surfaced in the agent card |
 | `timeout` | no | Max seconds to wait for completion |
-| `mcp` | no | Present = exposed as MCP tool; requires `inputSchema` |
-| `a2a` | no | Present = exposed as A2A skill |
+| `streaming` | no | Advertise SSE streaming support |
+| `skills` | no | A2A skills `[{id, name, description, tags?, examples?}]` |
+| `inputModes` / `outputModes` | no | MIME types (default `[text/plain, application/json]`) |
 
-### Step 2: Apply the ConfigMap
+**MCP tool** (`tools.yaml`): same `name` / `actor` / `description` / `timeout`, plus
+`inputSchema` (JSON Schema) and `progress` (bool — emit progress notifications).
 
-```bash
-kubectl create configmap gateway-flows \
-  -n asya-system \
-  --from-file=flows.yaml=flows.yaml \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
+### Manual ConfigMap edit
 
-Or patch the existing ConfigMap:
+For custom setups, edit the registry ConfigMaps directly (the gateway hot-reloads):
 
 ```bash
-kubectl patch configmap gateway-flows -n asya-system \
-  --type merge \
-  -p "$(cat <<'EOF'
-data:
-  flows.yaml: |
-    flows:
-    - name: echo
-      entrypoint: echo-actor
-      description: Echo handler
-      mcp:
-        inputSchema:
-          type: object
-          properties:
-            name:
-              type: string
-          required: [name]
-EOF
-)"
+kubectl edit configmap asya-gateway-a2a-agents   # data.agents.yaml -> agents: [...]
+kubectl edit configmap asya-gateway-mcp-tools    # data.tools.yaml  -> tools:  [...]
 ```
 
-### Step 3: Verify Registration
+### Verify Registration
 
 ```bash
 # List available tools via MCP

--- a/docs/usage/guide-agentic-patterns.md
+++ b/docs/usage/guide-agentic-patterns.md
@@ -781,29 +781,30 @@ from actors arrive at the client as streaming text chunks.
 
 ### Flow registry: exposing actor pipelines as tools/skills
 
-Which pipelines are exposed via A2A and MCP is configured in the
-`gateway-flows` ConfigMap:
+A pipeline is exposed as an A2A agent and/or MCP tool via two per-protocol registry
+ConfigMaps — `asya-gateway-a2a-agents` (`agents.yaml`) and `asya-gateway-mcp-tools`
+(`tools.yaml`). Each entry's `actor` is the pipeline's entrypoint actor:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gateway-flows
+  name: asya-gateway-a2a-agents
 data:
-  flows.yaml: |
-    flows:
+  agents.yaml: |
+    agents:
       - name: document-summarizer
         description: Summarizes documents using LLM
-        entrypoint: start-document-pipeline  # first actor in the pipeline
-        route_next:
-          - preprocessor
-          - llm-summarizer
-          - formatter
+        actor: start-document-pipeline   # first actor in the pipeline
+        streaming: true
+        skills:
+          - {id: document-summarizer, name: document-summarizer, description: Summarizes documents}
 ```
 
-The gateway polls this ConfigMap at runtime (configurable via
-`ASYA_CONFIG_POLL_INTERVAL`). Updating the ConfigMap updates the exposed
-tools without restarting the gateway.
+The gateway adapters poll these ConfigMaps at runtime (configurable via
+`ASYA_CONFIG_POLL_INTERVAL`). Updating a ConfigMap updates the exposed agents/tools
+without restarting the gateway. `asya k apply` upserts these entries for you; see
+[Gateway setup → Flow Registration](../setup/guide-gateway.md).
 
 ---
 

--- a/src/asya-lab/asya_lab/expose_cli.py
+++ b/src/asya-lab/asya_lab/expose_cli.py
@@ -1,7 +1,11 @@
-"""CLI commands for exposing and unexposing flows via gateway ConfigMap.
+"""CLI commands for exposing and unexposing flows via the gateway.
 
-Expose writes the gateway-flows ConfigMap into common/ (user overlay),
-and optionally enables it for a specific context via --context.
+`asya expose` writes a normalized flow-exposure intent (`flow-expose.yaml`) into the
+flow's manifests. `asya k apply` reads it and upserts the flow as an A2A agent and/or
+MCP tool into the gateway's shared, hot-reloaded ConfigMaps
+(`asya-gateway-a2a-agents` / `asya-gateway-mcp-tools`).
+
+The intent file is NOT a Kubernetes resource and is NOT added to kustomization.
 
     asya expose text-flow -d "Analyze text" --mcp --a2a
     asya expose text-flow -d "Analyze text" --mcp --a2a --context dev
@@ -21,12 +25,7 @@ import yaml
 from asya_lab.cli_types import ASYA_REF, AsyaRef
 from asya_lab.config.discovery import BASE_DIR, COMMON_DIR, OVERLAYS_DIR, find_asya_dir
 from asya_lab.config.project import AsyaProject
-
-
-def _get_dumper() -> type:
-    from asya_lab.compiler.templater import _Dumper
-
-    return _Dumper
+from asya_lab.gateway_register import EXPOSE_FILENAME, build_flow_expose
 
 
 def _load_project(flow_name: str | None = None) -> AsyaProject:
@@ -69,101 +68,6 @@ def _find_entrypoint(base_dir: Path) -> str:
     sys.exit(1)
 
 
-def _build_flow_config(
-    flow_name: str,
-    entrypoint: str,
-    description: str,
-    timeout: int | None,
-    *,
-    mcp: bool,
-    a2a: bool,
-    input_schema: dict | None,
-    tags: str | None,
-    examples: tuple[str, ...],
-    input_modes: str | None,
-    output_modes: str | None,
-) -> dict:
-    """Build the flow configuration data for the ConfigMap."""
-    flow_data: dict = {
-        "name": flow_name,
-        "entrypoint": entrypoint,
-        "description": description,
-    }
-    if timeout is not None:
-        flow_data["timeout"] = timeout
-
-    if mcp:
-        mcp_section: dict = {}
-        if input_schema is not None:
-            mcp_section["inputSchema"] = input_schema
-        flow_data["mcp"] = mcp_section
-
-    if a2a:
-        a2a_section: dict = {}
-        if tags:
-            a2a_section["tags"] = [t.strip() for t in tags.split(",")]
-        if examples:
-            a2a_section["examples"] = list(examples)
-        if input_modes:
-            a2a_section["input_modes"] = [m.strip() for m in input_modes.split(",")]
-        if output_modes:
-            a2a_section["output_modes"] = [m.strip() for m in output_modes.split(",")]
-        flow_data["a2a"] = a2a_section
-
-    return flow_data
-
-
-def _build_configmap(flow_name: str, flow_data: dict) -> dict:
-    """Build a per-flow gateway ConfigMap.
-
-    Each flow gets its own CM with label asya.sh/config-type: flows.
-    The gateway reads all *.yaml files in its config directory,
-    so multiple per-flow CMs coexist.
-    """
-    flows_wrapper = {"flows": [flow_data]}
-    flow_yaml = yaml.dump(flows_wrapper, Dumper=_get_dumper(), default_flow_style=False, sort_keys=False)
-    return {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {
-            "name": f"asya-flow-{flow_name}-config",
-            "labels": {
-                "asya.sh/flow": flow_name,
-                "asya.sh/config-type": "flows",
-                "asya.sh/managed-by": "asya-lab",
-            },
-        },
-        "data": {
-            f"{flow_name}.yaml": flow_yaml,
-        },
-    }
-
-
-EXPOSE_FILENAME = "flow-expose.yaml"
-
-
-def _update_kustomization(kust_path: Path, resource: str, *, add: bool) -> bool:
-    """Add or remove a resource from a kustomization.yaml. Returns True if changed."""
-    if not kust_path.exists():
-        return False
-
-    kust = yaml.safe_load(kust_path.read_text()) or {}
-    resources = kust.get("resources", [])
-
-    if add:
-        if resource in resources:
-            return False
-        resources.append(resource)
-    else:
-        if resource not in resources:
-            return False
-        resources.remove(resource)
-
-    kust["resources"] = resources
-    kust_path.write_text(yaml.dump(kust, Dumper=_get_dumper(), default_flow_style=False, sort_keys=False))
-    return True
-
-
 def _resolve_input_schema(schema_inline: str | None, schema_file: str | None) -> dict | None:
     if schema_inline and schema_file:
         raise click.BadParameter("Specify only one of --input-schema or --input-schema-file")
@@ -190,12 +94,12 @@ def _rel(p: Path) -> str:
 )
 @click.option("--input-schema", "input_schema_inline", default=None, help="MCP: JSON Schema inline")
 @click.option("--input-schema-file", "input_schema_file", default=None, help="MCP: JSON Schema from file")
-@click.option("--a2a", "enable_a2a", is_flag=True, default=False, help="Expose as A2A skill")
+@click.option("--a2a", "enable_a2a", is_flag=True, default=False, help="Expose as A2A agent")
 @click.option("--tags", default=None, help="A2A: comma-separated skill tags")
 @click.option("--examples", multiple=True, help="A2A: example prompts (repeatable)")
 @click.option("--input-modes", default=None, help="A2A: comma-separated input MIME types")
 @click.option("--output-modes", default=None, help="A2A: comma-separated output MIME types")
-@click.option("--context", "ctx", default=None, help="Enable for this context (adds to overlay)")
+@click.option("--context", "ctx", default=None, help="Write intent into this context's overlay")
 def expose(
     target,
     description,
@@ -210,10 +114,10 @@ def expose(
     output_modes,
     ctx,
 ):
-    """Expose a compiled flow to the gateway via ConfigMap.
+    """Expose a compiled flow to the gateway.
 
-    Creates the flow config in common/ (user overlay). Use --context to
-    enable it for a specific environment.
+    Writes a flow-exposure intent that `asya k apply` upserts into the gateway's
+    A2A/MCP registry ConfigMaps. Use --context to target a specific overlay.
 
     \b
     Examples:
@@ -228,7 +132,6 @@ def expose(
     project = _load_project(flow_name)
     manifests_root = _find_manifests_root(project, flow_name)
     base_dir = manifests_root / BASE_DIR
-    common_dir = manifests_root / COMMON_DIR
 
     if not base_dir.is_dir():
         click.echo(f"[-] base/ not found: {base_dir}\n[-] Run 'asya compile' first.", err=True)
@@ -237,7 +140,7 @@ def expose(
     entrypoint = _find_entrypoint(base_dir)
     input_schema = _resolve_input_schema(input_schema_inline, input_schema_file)
 
-    flow_data = _build_flow_config(
+    intent = build_flow_expose(
         flow_name,
         entrypoint,
         description,
@@ -250,81 +153,51 @@ def expose(
         input_modes=input_modes,
         output_modes=output_modes,
     )
-    configmap = _build_configmap(flow_name, flow_data)
-
-    # Write CM to common/
-    common_dir.mkdir(parents=True, exist_ok=True)
-    cm_path = common_dir / EXPOSE_FILENAME
-    cm_path.write_text(yaml.dump(configmap, Dumper=_get_dumper(), default_flow_style=False, sort_keys=False))
-    click.echo(f"[+] {_rel(cm_path)}")
-
-    protocols = []
-    if enable_mcp:
-        protocols.append("mcp")
-    if enable_a2a:
-        protocols.append("a2a")
 
     if ctx:
-        # Enable for specific context: copy CM into overlay directory
-        overlay_dir = manifests_root / OVERLAYS_DIR / ctx
-        if not overlay_dir.is_dir():
-            click.echo(f"[-] Overlay not found: {overlay_dir}", err=True)
-            click.echo("[-] Run 'asya compile' first or create the overlay", err=True)
+        target_dir = manifests_root / OVERLAYS_DIR / ctx
+        if not target_dir.is_dir():
+            click.echo(f"[-] Overlay not found: {target_dir}\n[-] Run 'asya compile' first.", err=True)
             sys.exit(1)
-
-        overlay_cm = overlay_dir / EXPOSE_FILENAME
-        overlay_cm.write_text(cm_path.read_text())
-        overlay_kust = overlay_dir / "kustomization.yaml"
-        if _update_kustomization(overlay_kust, EXPOSE_FILENAME, add=True):
-            click.echo(f"[+] Enabled for context '{ctx}': {_rel(overlay_kust)}")
-        else:
-            click.echo(f"[.] Already enabled for context '{ctx}'")
     else:
-        # No context: add to common/ kustomization (all environments)
-        common_kust = common_dir / "kustomization.yaml"
-        if _update_kustomization(common_kust, EXPOSE_FILENAME, add=True):
-            click.echo(f"[+] Enabled in {_rel(common_kust)}")
-        else:
-            click.echo("[.] Already enabled in common/")
+        target_dir = manifests_root / COMMON_DIR
+        target_dir.mkdir(parents=True, exist_ok=True)
 
+    intent_path = target_dir / EXPOSE_FILENAME
+    intent_path.write_text(yaml.dump(intent, default_flow_style=False, sort_keys=False))
+    click.echo(f"[+] {_rel(intent_path)}")
+
+    protocols = [p for p, on in (("mcp", enable_mcp), ("a2a", enable_a2a)) if on]
     click.echo(f"[+] Flow '{flow_name}' exposed via {'+'.join(protocols)} (entrypoint: {entrypoint})")
+    suffix = f" --context {ctx}" if ctx else ""
+    click.echo(f"[.] Run 'asya k apply {flow_name}{suffix}' to register with the gateway.")
 
 
 @click.command("unexpose")
 @click.argument("target", type=ASYA_REF)
-@click.option("--context", "ctx", default=None, help="Disable for this context only")
+@click.option("--context", "ctx", default=None, help="Remove from this context's overlay only")
 def unexpose(target: AsyaRef, ctx: str | None):
-    """Remove flow exposure from the gateway.
+    """Remove a flow's gateway-exposure intent.
 
     \b
-    Without --context: removes the flow config from common/ entirely.
-    With --context: removes only the overlay reference (keeps config in common/).
+    Without --context: removes the intent from common/.
+    With --context: removes the intent from the context overlay.
+
+    Note: this removes the local intent only. To drop an already-registered flow
+    from the running gateway, edit the asya-gateway-a2a-agents / asya-gateway-mcp-tools
+    ConfigMap (the gateway hot-reloads the removal).
     """
     flow_name = target.name
     project = _load_project(flow_name)
     manifests_root = _find_manifests_root(project, flow_name)
-    common_dir = manifests_root / COMMON_DIR
 
-    if ctx:
-        # Remove from specific overlay
-        overlay_dir = manifests_root / OVERLAYS_DIR / ctx
-        overlay_kust = overlay_dir / "kustomization.yaml"
-        if _update_kustomization(overlay_kust, EXPOSE_FILENAME, add=False):
-            click.echo(f"[+] Disabled for context '{ctx}'")
-        else:
-            click.echo(f"[.] Not enabled for context '{ctx}'")
-        overlay_cm = overlay_dir / EXPOSE_FILENAME
-        if overlay_cm.exists():
-            overlay_cm.unlink()
+    target_dir = (manifests_root / OVERLAYS_DIR / ctx) if ctx else (manifests_root / COMMON_DIR)
+    intent_path = target_dir / EXPOSE_FILENAME
+
+    if intent_path.exists():
+        intent_path.unlink()
+        click.echo(f"[+] Removed {_rel(intent_path)}")
+        scope = f"context '{ctx}'" if ctx else "common/"
+        click.echo(f"[+] Flow '{flow_name}' unexposed from {scope}")
     else:
-        # Remove from common/ entirely
-        cm_path = common_dir / EXPOSE_FILENAME
-        if cm_path.exists():
-            cm_path.unlink()
-            click.echo(f"[+] Removed {_rel(cm_path)}")
-        else:
-            click.echo(f"[.] {EXPOSE_FILENAME} not found in common/")
-
-        common_kust = common_dir / "kustomization.yaml"
-        _update_kustomization(common_kust, EXPOSE_FILENAME, add=False)
-        click.echo(f"[+] Flow '{flow_name}' unexposed")
+        click.echo(f"[.] {EXPOSE_FILENAME} not found in {_rel(target_dir)}")

--- a/src/asya-lab/asya_lab/gateway_register.py
+++ b/src/asya-lab/asya_lab/gateway_register.py
@@ -1,0 +1,158 @@
+"""Flow → gateway registration for the split gateway.
+
+A compiled flow is exposed to the gateway as an A2A *agent* and/or an MCP *tool*.
+`asya expose` / `asya patch --gateway` write a normalized intent file
+(`flow-expose.yaml`) into the flow's manifests; `asya k apply` reads it and upserts
+the entry into the gateway's shared, hot-reloaded ConfigMaps:
+
+- A2A agents: ``asya-gateway-a2a-agents`` → ``data["agents.yaml"]`` = ``{agents: [...]}``
+- MCP tools:  ``asya-gateway-mcp-tools``  → ``data["tools.yaml"]``  = ``{tools: [...]}``
+
+The a2a/mcp adapters watch their mounted ConfigMap and hot-reload within
+``ASYA_CONFIG_POLL_INTERVAL`` (default 10s) once the kubelet propagates the change
+(up to ~60s). No deployment patch and no Helm upgrade are required.
+
+The intent file is NOT a Kubernetes resource and is NOT added to kustomization —
+it is consumed only by `asya k apply`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+import yaml
+
+
+# Gateway ConfigMaps follow the chart fullname convention for release "asya-gateway".
+A2A_AGENTS_CM = "asya-gateway-a2a-agents"
+MCP_TOOLS_CM = "asya-gateway-mcp-tools"
+
+# Filename of the normalized flow-exposure intent, written by expose / patch --gateway.
+EXPOSE_FILENAME = "flow-expose.yaml"
+
+_DEFAULT_MODES = ["text/plain", "application/json"]
+
+
+def _modes(value: str | None) -> list[str]:
+    if value:
+        return [m.strip() for m in value.split(",") if m.strip()]
+    return list(_DEFAULT_MODES)
+
+
+def build_flow_expose(
+    flow_name: str,
+    entrypoint: str,
+    description: str,
+    timeout: int | None,
+    *,
+    mcp: bool,
+    a2a: bool,
+    input_schema: dict | None = None,
+    tags: str | None = None,
+    examples: tuple[str, ...] = (),
+    input_modes: str | None = None,
+    output_modes: str | None = None,
+    progress: bool = True,
+    streaming: bool = True,
+) -> dict:
+    """Build the normalized flow-exposure intent for the split gateway.
+
+    Produces an ``a2a`` agent entry and/or an ``mcp`` tool entry in the exact shape
+    the gateway's ``agents.yaml`` / ``tools.yaml`` expect. ``entrypoint`` (the
+    ``start-<flow>`` actor) becomes the entry's ``actor``.
+    """
+    intent: dict = {"flow": flow_name}
+
+    if a2a:
+        agent: dict = {"name": flow_name, "description": description, "actor": entrypoint}
+        if timeout is not None:
+            agent["timeout"] = timeout
+        agent["streaming"] = streaming
+        skill: dict = {"id": flow_name, "name": flow_name, "description": description}
+        if tags:
+            skill["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+        if examples:
+            skill["examples"] = list(examples)
+        agent["skills"] = [skill]
+        agent["inputModes"] = _modes(input_modes)
+        agent["outputModes"] = _modes(output_modes)
+        intent["a2a"] = agent
+
+    if mcp:
+        tool: dict = {"name": flow_name, "description": description, "actor": entrypoint}
+        if timeout is not None:
+            tool["timeout"] = timeout
+        if input_schema is not None:
+            tool["inputSchema"] = input_schema
+        tool["progress"] = progress
+        intent["mcp"] = tool
+
+    return intent
+
+
+def find_flow_expose(overlay: Path, manifests_dir: Path) -> Path | None:
+    """Locate the flow-exposure intent, preferring the resolved overlay over common/."""
+    for candidate in (overlay / EXPOSE_FILENAME, manifests_dir / "common" / EXPOSE_FILENAME):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _upsert(items: list[dict], entry: dict) -> list[dict]:
+    """Upsert ``entry`` into ``items`` keyed by ``name`` (idempotent)."""
+    out = [it for it in items if it.get("name") != entry.get("name")]
+    out.append(entry)
+    return out
+
+
+def _patch_registry_cm(runner, cm_name: str, data_key: str, list_key: str, entry: dict) -> bool:
+    """Get the gateway registry ConfigMap, upsert ``entry``, and patch it back.
+
+    Returns True on success, False if the ConfigMap is absent (protocol not enabled).
+    """
+    got = runner.kubectl("get", "cm", cm_name, "-o", "json", quiet=True, capture_output=True, text=True)
+    if got.returncode != 0:
+        click.echo(f"[!] Gateway ConfigMap '{cm_name}' not found — is that protocol enabled? Skipping.", err=True)
+        return False
+
+    cm = json.loads(got.stdout)
+    raw = (cm.get("data") or {}).get(data_key, "") or ""
+    parsed = yaml.safe_load(raw) or {}
+    items = parsed.get(list_key) or []
+    items = _upsert(items, entry)
+
+    new_yaml = yaml.dump({list_key: items}, default_flow_style=False, sort_keys=False)
+    patch = json.dumps({"data": {data_key: new_yaml}})
+    res = runner.kubectl(
+        "patch", "cm", cm_name, "--type", "merge", "-p", patch, quiet=True, capture_output=True, text=True
+    )
+    if res.returncode != 0:
+        click.echo(f"[-] Failed to patch '{cm_name}': {res.stderr.strip()}", err=True)
+        return False
+    return True
+
+
+def register_flow_with_gateway(runner, overlay: Path, manifests_dir: Path) -> None:
+    """Upsert a flow's a2a/mcp entries into the gateway registry ConfigMaps.
+
+    Reads the flow-exposure intent (if present) and merges its entries into the
+    shared, hot-reloaded gateway ConfigMaps. No-op if the flow was not exposed.
+    """
+    intent_path = find_flow_expose(overlay, manifests_dir)
+    if intent_path is None:
+        return
+
+    intent = yaml.safe_load(intent_path.read_text()) or {}
+    flow_name = intent.get("flow", "?")
+    registered = []
+
+    if intent.get("a2a") and _patch_registry_cm(runner, A2A_AGENTS_CM, "agents.yaml", "agents", intent["a2a"]):
+        registered.append(f"a2a→{A2A_AGENTS_CM}")
+    if intent.get("mcp") and _patch_registry_cm(runner, MCP_TOOLS_CM, "tools.yaml", "tools", intent["mcp"]):
+        registered.append(f"mcp→{MCP_TOOLS_CM}")
+
+    if registered:
+        click.echo(f"[+] Registered flow '{flow_name}' with gateway ({', '.join(registered)})")
+        click.echo("[.] Gateway hot-reloads the registry within ~60s (ConfigMap propagation).")

--- a/src/asya-lab/asya_lab/k_cli.py
+++ b/src/asya-lab/asya_lab/k_cli.py
@@ -23,6 +23,7 @@ from asya_lab.config.discovery import (
     find_asya_dir,
 )
 from asya_lab.config.project import AsyaProject
+from asya_lab.gateway_register import register_flow_with_gateway
 
 
 # ---------------------------------------------------------------------------
@@ -188,94 +189,6 @@ def _find_flow_for_actor(manifests_dir: Path, actor_name: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _register_flow_with_gateway(runner: KubeRunner, flow_name: str) -> None:
-    """Patch the gateway deployment to mount the per-flow ConfigMap.
-
-    After `asya k apply` deploys a flow-expose CM (asya-flow-<name>-config),
-    this patches the gateway-api deployment's projected volume to include it.
-    Idempotent — skips if the CM doesn't exist or is already mounted.
-    """
-    import json as _json
-
-    cm_name = f"asya-flow-{flow_name}-config"
-
-    # Check if the per-flow CM exists
-    result = runner.kubectl(
-        "get",
-        "cm",
-        cm_name,
-        "-o",
-        "name",
-        quiet=True,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return
-
-    # Check if already in the projected volume
-    result = runner.kubectl(
-        "get",
-        "deployment",
-        "asya-gateway-api",
-        "-o",
-        "jsonpath={.spec.template.spec.volumes[?(@.name=='gateway-flows')].projected.sources}",
-        quiet=True,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return
-    if cm_name in result.stdout:
-        return
-
-    # Find the volume index for gateway-flows
-    vol_result = runner.kubectl(
-        "get",
-        "deployment",
-        "asya-gateway-api",
-        "-o",
-        "jsonpath={.spec.template.spec.volumes}",
-        quiet=True,
-        capture_output=True,
-        text=True,
-    )
-    if vol_result.returncode != 0:
-        return
-
-    volumes = _json.loads(vol_result.stdout)
-    vol_idx = next((i for i, v in enumerate(volumes) if v.get("name") == "gateway-flows"), None)
-    if vol_idx is None:
-        return
-
-    # Only works with projected volumes (requires chart change)
-    if "projected" not in volumes[vol_idx]:
-        return
-
-    sources = volumes[vol_idx]["projected"].get("sources", [])
-    source_idx = len(sources)
-
-    patch = [
-        {
-            "op": "add",
-            "path": f"/spec/template/spec/volumes/{vol_idx}/projected/sources/{source_idx}",
-            "value": {"configMap": {"name": cm_name, "optional": True}},
-        }
-    ]
-    patch_result = runner.kubectl(
-        "patch",
-        "deployment",
-        "asya-gateway-api",
-        "--type=json",
-        f"-p={_json.dumps(patch)}",
-        quiet=True,
-        capture_output=True,
-        text=True,
-    )
-    if patch_result.returncode == 0:
-        click.echo(f"[+] Registered flow '{flow_name}' with gateway (projected volume)")
-
-
 @click.command()
 @click.argument("target", type=ASYA_REF, required=False, default=None)
 @click.option("--context", "ctx", default=None, help="K8s context from .asya/config.yaml")
@@ -286,9 +199,9 @@ def apply(target: AsyaRef | None, ctx: str, verbose: bool) -> None:
     TARGET is a flow name (kebab-case, snake_case, or path/to/flow.py).
 
     Uses kustomize build piped to kubectl apply --server-side with
-    per-flow field manager for safe, idempotent deploys. If the flow
-    includes a gateway-flows ConfigMap (from `asya expose`), the
-    gateway deployment is automatically patched to mount it.
+    per-flow field manager for safe, idempotent deploys. If the flow was
+    exposed (`asya expose` / `asya patch --gateway`), its A2A/MCP entry is
+    upserted into the gateway's registry ConfigMaps, which hot-reload.
     """
     if target is None:
         raise click.MissingParameter(
@@ -301,7 +214,7 @@ def apply(target: AsyaRef | None, ctx: str, verbose: bool) -> None:
     overlay = runner.resolve_overlay(manifests_dir)
 
     runner.kustomize_apply(overlay, field_manager=f"asya-flow-{target.name}")
-    _register_flow_with_gateway(runner, target.name)
+    register_flow_with_gateway(runner, overlay, manifests_dir)
 
     # Rollout restart to pick up ConfigMap changes (routers, adapters)
     result = runner.kubectl(
@@ -807,9 +720,12 @@ def _print_port_forward_hint(url: str, ctx_config: dict | None) -> None:
 
     click.echo("[.] Run in a separate terminal:", err=True)
 
-    gw = _find_svc("app.kubernetes.io/name=asya-gateway,asya.sh/gateway-mode=api", [actor_ns, "asya-system"])
-    gw_svc = f"-n {gw[0]} svc/{gw[1]}" if gw else f"-n {actor_ns} svc/asya-gateway-api"
-    click.echo(f"    kubectl port-forward {gw_svc} {gw_port}:80  # required", err=True)
+    gw = _find_svc("app.kubernetes.io/name=asya-gateway,app.kubernetes.io/component=a2a", [actor_ns, "asya-system"])
+    gw_svc = f"-n {gw[0]} svc/{gw[1]}" if gw else f"-n {actor_ns} svc/asya-gateway-a2a"
+    click.echo(
+        f"    kubectl port-forward {gw_svc} {gw_port}:8083  # required (A2A; use svc/asya-gateway-mcp {gw_port}:8082 for --mcp)",
+        err=True,
+    )
 
     for key, label, default_port, comment in [
         ("tempo_url", "app.kubernetes.io/name=tempo", 3200, "for --trace"),
@@ -1426,10 +1342,10 @@ def _resolve_gateway_url(runner: KubeRunner, url_override: str | None) -> str:
 
     click.echo(
         "[-] No gateway URL configured. Options:\n"
-        "    1. Set in .asya/config.yaml: contexts.dev.gateway: http://...\n"
+        "    1. Set in .asya/config.yaml: contexts.dev.gateway_url: http://...\n"
         "    2. Set env: export ASYA_GATEWAY_URL=http://...\n"
         "    3. Use flag: --url http://...\n"
-        "    4. Start port-forward: kubectl port-forward -n <ns> svc/asya-gateway-api 18080:80",
+        "    4. Start port-forward: kubectl port-forward -n <ns> svc/asya-gateway-a2a 18080:8083",
         err=True,
     )
     sys.exit(1)

--- a/src/asya-lab/asya_lab/patch_cli.py
+++ b/src/asya-lab/asya_lab/patch_cli.py
@@ -23,17 +23,7 @@ import yaml
 from asya_lab.cli_types import ASYA_REF, AsyaRef
 from asya_lab.config.discovery import BASE_DIR, COMMON_DIR, OVERLAYS_DIR, find_asya_dir
 from asya_lab.config.project import AsyaProject
-
-
-class _LiteralStr(str):
-    """String subclass that yaml.dump renders as a block scalar (|)."""
-
-
-def _literal_representer(dumper: yaml.Dumper, data: _LiteralStr) -> yaml.ScalarNode:
-    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
-
-
-yaml.add_representer(_LiteralStr, _literal_representer)
+from asya_lab.gateway_register import EXPOSE_FILENAME, build_flow_expose
 
 
 # -- Shorthand key mapping --------------------------------------------------
@@ -151,7 +141,7 @@ def _build_gateway_config(
     entrypoint: str,
     key_values: tuple[str, ...],
 ) -> dict | None:
-    """Build the gateway flow-expose ConfigMap from key=value pairs.
+    """Build the flow-exposure intent from key=value pairs.
 
     Returns None if expose=false (removal).
     """
@@ -174,42 +164,22 @@ def _build_gateway_config(
     if not has_mcp and not has_a2a:
         raise click.UsageError("--gateway requires at least one protocol: mcp=true and/or a2a=true")
 
-    flow_data: dict = {
-        "name": flow_name,
-        "entrypoint": entrypoint,
-        "description": description,
-    }
-
-    if has_mcp:
-        flow_data["mcp"] = {}
-    if has_a2a:
-        flow_data["a2a"] = {}
-
     timeout = kv_dict.pop("timeout", None)
-    if timeout is not None:
-        flow_data["timeout"] = int(timeout)
+    tags = kv_dict.pop("tags", None)
+    input_modes = kv_dict.pop("input_modes", None) or kv_dict.pop("inputModes", None)
+    output_modes = kv_dict.pop("output_modes", None) or kv_dict.pop("outputModes", None)
 
-    # Remaining keys go as-is
-    flow_data.update(kv_dict)
-
-    flows_wrapper = {"flows": [flow_data]}
-    flow_yaml = yaml.dump(flows_wrapper, default_flow_style=False, sort_keys=False)
-
-    return {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {
-            "name": f"asya-flow-{flow_name}-config",
-            "labels": {
-                "asya.sh/flow": flow_name,
-                "asya.sh/config-type": "flows",
-                "asya.sh/managed-by": "asya-lab",
-            },
-        },
-        "data": {
-            f"{flow_name}.yaml": _LiteralStr(flow_yaml),
-        },
-    }
+    return build_flow_expose(
+        flow_name,
+        entrypoint,
+        description,
+        int(timeout) if timeout is not None else None,
+        mcp=has_mcp,
+        a2a=has_a2a,
+        tags=str(tags) if tags is not None else None,
+        input_modes=str(input_modes) if input_modes is not None else None,
+        output_modes=str(output_modes) if output_modes is not None else None,
+    )
 
 
 def _find_entrypoint(base_dir: Path) -> str:
@@ -231,8 +201,6 @@ def _find_entrypoint(base_dir: Path) -> str:
 
 
 # -- File operations ---------------------------------------------------------
-
-EXPOSE_FILENAME = "flow-expose.yaml"
 
 
 def _resolve_actors(base_dir: Path) -> list[str]:
@@ -465,24 +433,21 @@ def patch(
             raise click.UsageError("-p is not supported with --gateway")
 
         entrypoint = _find_entrypoint(base_dir)
-        cm = _build_gateway_config(flow_name.name, entrypoint, key_values)
+        intent = _build_gateway_config(flow_name.name, entrypoint, key_values)
 
-        cm_path = patch_dir / EXPOSE_FILENAME
-        kust_path = patch_dir / "kustomization.yaml"
+        # Intent is consumed by `asya k apply`; it is NOT a kustomize resource.
+        intent_path = patch_dir / EXPOSE_FILENAME
 
-        if cm is None:
+        if intent is None:
             # expose=false: remove
-            if cm_path.exists():
-                cm_path.unlink()
-            _update_kustomization(kust_path, EXPOSE_FILENAME, add=False, field="resources")
-            click.echo(f"[+] Gateway config removed for '{flow_name.name}'")
+            if intent_path.exists():
+                intent_path.unlink()
+            click.echo(f"[+] Gateway exposure removed for '{flow_name.name}'")
         else:
             patch_dir.mkdir(parents=True, exist_ok=True)
-            cm_path.write_text(yaml.dump(cm, default_flow_style=False, sort_keys=False))
-            added = _update_kustomization(kust_path, EXPOSE_FILENAME, add=True, field="resources")
-            click.echo(f"[+] {_rel(cm_path)}")
-            if added:
-                click.echo(f"[+] Registered in {_rel(kust_path)}")
+            intent_path.write_text(yaml.dump(intent, default_flow_style=False, sort_keys=False))
+            click.echo(f"[+] {_rel(intent_path)}")
+            click.echo(f"[.] Run 'asya k apply {flow_name.name}' to register with the gateway.")
         return
 
     # -- Actor scope ---------------------------------------------------------

--- a/src/asya-lab/tests/test_expose_cli.py
+++ b/src/asya-lab/tests/test_expose_cli.py
@@ -78,7 +78,7 @@ def test_unexpose_help():
     assert "target" in result.output.lower()
 
 
-def test_expose_creates_configmap(tmp_path: Path):
+def test_expose_creates_intent_mcp_default(tmp_path: Path):
     _setup_project(tmp_path)
 
     runner = CliRunner()
@@ -89,8 +89,51 @@ def test_expose_creates_configmap(tmp_path: Path):
     assert result.exit_code == 0, result.output
 
     common_dir = tmp_path / "compiled" / "my-flow" / "manifests" / "common"
-    cm_path = common_dir / EXPOSE_FILENAME
-    assert cm_path.exists(), f"Expected {cm_path} to exist"
+    intent_path = common_dir / EXPOSE_FILENAME
+    assert intent_path.exists(), f"Expected {intent_path} to exist"
 
-    cm = yaml.safe_load(cm_path.read_text())
-    assert cm["kind"] == "ConfigMap"
+    intent = yaml.safe_load(intent_path.read_text())
+    # New format: a normalized intent doc, NOT a k8s ConfigMap.
+    assert "kind" not in intent
+    assert intent["flow"] == "my-flow"
+    # Default protocol is MCP; entrypoint (start actor) becomes `actor`.
+    assert intent["mcp"]["name"] == "my-flow"
+    assert intent["mcp"]["actor"] == "start-my-flow"
+    assert intent["mcp"]["description"] == "Test flow"
+    assert "a2a" not in intent
+
+
+def test_expose_a2a_emits_agent_entry(tmp_path: Path):
+    _setup_project(tmp_path)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        os.chdir(tmp_path)
+        result = runner.invoke(expose, ["my-flow", "--description", "Test flow", "--a2a"])
+
+    assert result.exit_code == 0, result.output
+
+    common_dir = tmp_path / "compiled" / "my-flow" / "manifests" / "common"
+    intent = yaml.safe_load((common_dir / EXPOSE_FILENAME).read_text())
+    agent = intent["a2a"]
+    assert agent["name"] == "my-flow"
+    assert agent["actor"] == "start-my-flow"
+    assert agent["streaming"] is True
+    assert agent["skills"][0]["id"] == "my-flow"
+    assert agent["inputModes"] == ["text/plain", "application/json"]
+    assert "mcp" not in intent
+
+
+def test_expose_does_not_touch_kustomization(tmp_path: Path):
+    _setup_project(tmp_path)
+    common_dir = tmp_path / "compiled" / "my-flow" / "manifests" / "common"
+    before = (common_dir / "kustomization.yaml").read_text()
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        os.chdir(tmp_path)
+        result = runner.invoke(expose, ["my-flow", "--description", "Test flow", "--a2a"])
+
+    assert result.exit_code == 0, result.output
+    # The intent is consumed by `asya k apply`, not by kustomize.
+    assert (common_dir / "kustomization.yaml").read_text() == before

--- a/src/asya-lab/tests/test_gateway_register.py
+++ b/src/asya-lab/tests/test_gateway_register.py
@@ -1,0 +1,123 @@
+"""Tests for flow → gateway registration (split gateway, shared registry CMs)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+from asya_lab.gateway_register import (
+    A2A_AGENTS_CM,
+    EXPOSE_FILENAME,
+    MCP_TOOLS_CM,
+    build_flow_expose,
+    register_flow_with_gateway,
+)
+
+
+def test_build_flow_expose_a2a_and_mcp():
+    intent = build_flow_expose(
+        "text-improver",
+        "start-text-improver",
+        "Improve text",
+        120,
+        mcp=True,
+        a2a=True,
+        input_schema={"type": "object"},
+    )
+    assert intent["flow"] == "text-improver"
+
+    agent = intent["a2a"]
+    assert agent == {
+        "name": "text-improver",
+        "description": "Improve text",
+        "actor": "start-text-improver",
+        "timeout": 120,
+        "streaming": True,
+        "skills": [{"id": "text-improver", "name": "text-improver", "description": "Improve text"}],
+        "inputModes": ["text/plain", "application/json"],
+        "outputModes": ["text/plain", "application/json"],
+    }
+
+    tool = intent["mcp"]
+    assert tool == {
+        "name": "text-improver",
+        "description": "Improve text",
+        "actor": "start-text-improver",
+        "timeout": 120,
+        "inputSchema": {"type": "object"},
+        "progress": True,
+    }
+
+
+def test_build_flow_expose_a2a_only_omits_mcp():
+    intent = build_flow_expose("f", "start-f", "d", None, mcp=False, a2a=True)
+    assert "mcp" not in intent
+    assert "timeout" not in intent["a2a"]
+
+
+class FakeRunner:
+    """Minimal KubeRunner stand-in backed by an in-memory ConfigMap store."""
+
+    def __init__(self, cms: dict):
+        self.cms = cms
+
+    def kubectl(self, *args, **kwargs):
+        if args[:2] == ("get", "cm"):
+            name = args[2]
+            if name not in self.cms:
+                return SimpleNamespace(returncode=1, stdout="", stderr="NotFound")
+            return SimpleNamespace(returncode=0, stdout=json.dumps(self.cms[name]), stderr="")
+        if args[:2] == ("patch", "cm"):
+            name = args[2]
+            payload = json.loads(args[args.index("-p") + 1])
+            self.cms.setdefault(name, {"data": {}}).setdefault("data", {}).update(payload["data"])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _write_intent(overlay: Path, intent: dict) -> None:
+    overlay.mkdir(parents=True, exist_ok=True)
+    (overlay / EXPOSE_FILENAME).write_text(yaml.dump(intent, sort_keys=False))
+
+
+def test_register_upserts_a2a_and_is_idempotent(tmp_path: Path):
+    overlay = tmp_path / "overlays" / "dev"
+    intent = build_flow_expose("hello", "start-hello", "Hi", 60, mcp=False, a2a=True)
+    _write_intent(overlay, intent)
+
+    cms = {A2A_AGENTS_CM: {"data": {"agents.yaml": "agents: []\n"}}}
+    runner = FakeRunner(cms)
+
+    register_flow_with_gateway(runner, overlay, tmp_path)
+    agents = yaml.safe_load(cms[A2A_AGENTS_CM]["data"]["agents.yaml"])["agents"]
+    assert [a["name"] for a in agents] == ["hello"]
+    assert agents[0]["actor"] == "start-hello"
+
+    # Re-registering the same flow does not duplicate the entry.
+    register_flow_with_gateway(runner, overlay, tmp_path)
+    agents = yaml.safe_load(cms[A2A_AGENTS_CM]["data"]["agents.yaml"])["agents"]
+    assert [a["name"] for a in agents] == ["hello"]
+
+
+def test_register_upserts_mcp_into_tools_cm(tmp_path: Path):
+    overlay = tmp_path / "overlays" / "dev"
+    intent = build_flow_expose("echo", "start-echo", "Echo", None, mcp=True, a2a=False)
+    _write_intent(overlay, intent)
+
+    cms = {MCP_TOOLS_CM: {"data": {"tools.yaml": "tools: []\n"}}}
+    register_flow_with_gateway(FakeRunner(cms), overlay, tmp_path)
+
+    tools = yaml.safe_load(cms[MCP_TOOLS_CM]["data"]["tools.yaml"])["tools"]
+    assert [t["name"] for t in tools] == ["echo"]
+
+
+def test_register_noop_without_intent(tmp_path: Path):
+    overlay = tmp_path / "overlays" / "dev"
+    overlay.mkdir(parents=True)
+    cms: dict = {A2A_AGENTS_CM: {"data": {"agents.yaml": "agents: []\n"}}}
+    runner = FakeRunner(cms)
+    # No flow-expose.yaml present -> no changes.
+    register_flow_with_gateway(runner, overlay, tmp_path)
+    assert yaml.safe_load(cms[A2A_AGENTS_CM]["data"]["agents.yaml"])["agents"] == []


### PR DESCRIPTION
## What

Migrates `asya-lab` flow→gateway registration from the legacy single-gateway model to the **split gateway** (mesh-api + a2a/mcp adapters).

The split gateway registers agents/tools from two shared, hot-reloaded ConfigMaps — `asya-gateway-a2a-agents` (`agents.yaml`) and `asya-gateway-mcp-tools` (`tools.yaml`) — instead of a per-flow `gateway-flows` ConfigMap mounted via projected volume into `asya-gateway-api`. The old `asya k apply` path patched the `asya-gateway-api` deployment, which **no longer exists**, so exposed flows were silently never registered.

## Changes

- **New** `asya_lab/gateway_register.py`:
  - `build_flow_expose()` — emits a typed a2a/mcp **intent** (flow `entrypoint` → entry `actor`).
  - `register_flow_with_gateway()` — upserts the entry **by name** into the shared registry ConfigMaps via `kubectl patch`; adapters hot-reload (~10s poll; kubelet CM propagation up to ~60s).
- `expose_cli.py` / `patch_cli.py` (`--gateway`) — write `flow-expose.yaml` as **intent only** (not a k8s resource, not added to kustomization).
- `k_cli.py` — `asya k apply` calls the new register; removed the dead `asya-gateway-api` projected-volume patch.
- **Tests** — new `test_gateway_register.py` (builder + upsert idempotency); updated `test_expose_cli.py`.
- **Docs** — `docs/setup/guide-gateway.md` (Flow Registration section), `docs/usage/guide-agentic-patterns.md`.

No backward-compat kept (pre-release, no users). Net **−700/+210** lines (mostly legacy removal).

## Testing

- `make -C src/asya-lab test-unit` — 638 passed, 1 skipped; ruff clean.
- **Live**: registered a second agent through the new path against a real split gateway → CM upserted (existing entry preserved) → hot-reloaded → `asya k send <agent>` returned the expected result.

## Out of scope

The broader gateway-architecture doc staleness (PostgreSQL, api/mesh single-pod modes, `asya-gateway-api` service name) in `core-gateway.md`, `env-vars.md`, `guide-pause-resume.md`, `guide-timeouts.md`, `start-gcp-gke.md` — separate docs PR.