### PR TITLE
docs: update gateway docs for the split-gateway architecture

### DIFF
--- a/docs/concepts/http-gateway.md
+++ b/docs/concepts/http-gateway.md
@@ -17,21 +17,24 @@ for results. Endpoints are organized into three namespaces:
 |-----------|----------|----------|---------|
 | `/a2a/` | A2A (Agent-to-Agent) | AI agents, orchestrators | `POST /a2a/` — SendMessage |
 | `/mcp` | MCP (Model Context Protocol) | LLM clients, developers | `POST /mcp` — tool invocation |
-| `/mesh/` | REST (internal) | Sidecars, operators | `POST /mesh` — progress/final callbacks |
+| `/api/v1/mesh/` | REST (internal) | Sidecars, operators | `POST /api/v1/mesh/{id}/events` — status/FLY callbacks |
 
 Special root routes: `/.well-known/agent.json` (A2A Agent Card discovery) and
 `/health` (K8s liveness/readiness probe).
 
-## Two deployment modes
+## Split containers
 
-The gateway runs as a single binary in one of two modes:
+The gateway is one image (`asya-gateway`) that ships several binaries, each running
+as a container in a single pod:
 
-- **api** — handles external traffic (A2A, MCP, REST). Exposed via Ingress or
-  LoadBalancer
-- **mesh** — handles internal sidecar callbacks (progress, FLY events, final
-  results). Cluster-internal only
+- **mesh-api** — core HTTP server: task CRUD, SSE, queue publish, and the internal
+  `/api/v1/mesh/` callbacks from sidecars
+- **mcp-adapter** — MCP HTTP, backed by mesh-api
+- **a2a-adapter** — A2A JSON-RPC, backed by mesh-api
+- **state-proxy-mesh** — task state sidecar
 
-Both modes share the same database (PostgreSQL) for task state.
+Task state is pluggable: PostgreSQL (`pg-kv`, default) or local files / in-memory
+(`pvc-kv`, no database required).
 
 ## Real-time streaming
 
@@ -64,4 +67,4 @@ This enables interoperability with any A2A-compliant agent framework.
 - [Gateway API specification](../reference/specs/gateway-api.md) — endpoint
   reference, request/response formats
 - [Gateway setup guide](../setup/guide-gateway.md) — deployment, TLS,
-  PostgreSQL configuration
+  state backend configuration

--- a/docs/reference/components/core-gateway.md
+++ b/docs/reference/components/core-gateway.md
@@ -1,53 +1,78 @@
 ---
-description: "Gateway (Go): MCP/A2A HTTP bridge, api/mesh modes, task state, PostgreSQL, SSE streaming"
+description: "Gateway (Go): split mesh-api + mcp-adapter + a2a-adapter containers, pluggable pg-kv/pvc-kv state, SSE streaming"
 ---
 
 # Gateway
 
 ## Responsibilities
 
-- Expose MCP-compliant HTTP API
+- Expose MCP- and A2A-compliant HTTP APIs
 - Create tasks from HTTP requests
-- Track task status in PostgreSQL
+- Track task status in a pluggable state backend (PostgreSQL or local files)
 - Stream progress updates and ephemeral FLY events via Server-Sent Events (SSE)
-- Receive status reports from crew actors
-- Broadcast FLY events via PG LISTEN/NOTIFY for cross-process delivery
+- Receive status reports from sidecars and crew actors
+- Fan out SSE events to subscribed clients
 
 ## How It Works
 
-1. Client calls MCP tool via HTTP POST
-2. Gateway creates task with unique ID
-3. Gateway stores task in PostgreSQL (status: `pending`)
-4. Gateway sends envelope to first actor's queue
-5. Crew actors (`x-sink`, `x-sump`) report final task status
-6. Client polls or streams task status updates via SSE
+1. Client calls an MCP tool or A2A skill via HTTP
+2. The adapter (mcp-adapter / a2a-adapter) forwards to the local mesh-api
+3. mesh-api creates a task with a unique ID (status: `pending`)
+4. mesh-api stores the task via the state-proxy sidecar
+5. mesh-api sends the envelope to the first actor's queue
+6. Crew actors (`x-sink`, `x-sump`) report final task status to mesh-api
+7. Client polls or streams task status updates via SSE
 
 ## Deployment
 
-The gateway binary supports three modes via `ASYA_GATEWAY_MODE`:
+The gateway is **one image** (`asya-gateway`) that ships three binaries. Each runs
+as a separate container in a single pod, selected via the container `command:`:
 
-| Mode | Routes | Use |
-|------|--------|-----|
-| `api` | A2A, MCP, OAuth, health | External-facing; behind Ingress |
-| `mesh` | Mesh routes, health | Internal-only; ClusterIP, no Ingress |
-| `testing` | All routes | Local development and integration tests |
+| Container | Command | Ports | Role |
+|-----------|---------|-------|------|
+| `mesh-api` | _(default entrypoint)_ | 8080 (external), 8081 (internal) | Core HTTP server: task CRUD, SSE, queue publish, sidecar callbacks |
+| `mcp-adapter` | `./mcp-adapter` | 8082 | MCP Streamable HTTP — translates `tools/list` / `tools/call` into mesh-api calls |
+| `a2a-adapter` | `./a2a-adapter` | 8083 | A2A JSON-RPC — implements the A2A protocol over mesh-api calls |
+
+A fourth container, the **state-proxy-mesh** sidecar, persists task/mesh state.
+The mesh-api never talks to a database directly — it issues KV operations to the
+state-proxy over a Unix socket, and the state-proxy translates them to its backend.
+
+The adapters are optional (`mcp.enabled` / `a2a.enabled` in Helm values). mesh-api
+and its state-proxy are always present.
+
+### State backend (pluggable)
+
+The state-proxy backend is selected by `stateProxy.mesh.backend`:
+
+| Backend | Storage | Replicas | When to use |
+|---------|---------|----------|-------------|
+| `pg-kv` _(default)_ | PostgreSQL | Multiple | Production; horizontal scaling, durable shared state |
+| `pvc-kv` | DuckDB over JSON files on a PVC, or in-memory | `replicaCount: 1` only | Lightweight deployments, demos, environments without PostgreSQL |
+
+**PostgreSQL is no longer mandatory.** With `pvc-kv` the gateway keeps task state
+in local files (or memory) and requires no external database. Because local storage
+is not shared across pods, `pvc-kv` enforces `replicaCount: 1` (the chart fails the
+render otherwise).
+
+The state layer is distinct from the pluggable **transports** (SQS, RabbitMQ,
+Pub/Sub) used to publish envelopes to actor queues, and from the actor-side
+**state proxy connectors** (S3, GCS, Redis, NATS KV) used for high-throughput data.
 
 ### State ownership
 
-The gateway uses two independent state stores with clearly separated ownership:
-
 ```
                         ┌─────────────────────────────┐
-                        │   gateway-flows ConfigMap   │
-                        │   (flows.yaml — K8s object) │
-                        └──────────────┬──────────────┘
-                                       │ polls every 10 s
-                                       │ (toolstore.Watch)
+   external client ───► │   mcp-adapter (:8082)       │
+   MCP                  │   a2a-adapter (:8083)       │
+   A2A                  └──────────────┬──────────────┘
+                                       │ POST /api/v1/mesh/ (create)
+                                       │ GET  /api/v1/mesh/{id} (status)
                         ┌──────────────▼──────────────┐
-   external client ───► │        api pod              │
-   MCP / A2A / OAuth    │  - MCP dispatch             │
-                        │  - A2A routing              │
-                        │  - agent card               │
+                        │   mesh-api external (:8080) │
+                        │   - task create / list      │
+                        │   - GET {id} / SSE events   │
+                        │   - DELETE {id} (cancel)    │
                         └──────────────┬──────────────┘
                                        │ sends envelope
                                        ▼
@@ -55,78 +80,43 @@ The gateway uses two independent state stores with clearly separated ownership:
                                        │
                                        ▼
                                   actor pod
-                                       │ POST /mesh/{id}/…
+                                       │ POST /api/v1/mesh/{id}/events
                         ┌──────────────▼──────────────┐
-                        │        mesh pod             │
-                        │  - progress callbacks       │
-                        │  - final status             │
-                        │  - SSE fan-out              │
+                        │   mesh-api internal (:8081) │
+                        │   - status + FLY callbacks  │
+                        │   - sidecar heartbeat (GET) │
                         └──────────────┬──────────────┘
-                                       │ reads / writes
+                                       │ KV ops over Unix socket
                         ┌──────────────▼──────────────┐
-                        │        PostgreSQL           │
-                        │  tasks, task_updates        │
-                        │  oauth_clients, tokens      │
+                        │   state-proxy-mesh sidecar  │
+                        │   pg-kv → PostgreSQL        │
+                        │   pvc-kv → local files/mem  │
                         └─────────────────────────────┘
-                                       ▲
-                        ───────────────┘
-                        api pod also reads/writes
-                        (task creation, OAuth, GetTask)
 ```
 
-**ConfigMap** (`gateway-flows`) — routing configuration:
+The mesh-api exposes **two ports**:
 
-| | api pod | mesh pod |
-|---|---|---|
-| Mounts ConfigMap | ✅ (`ASYA_CONFIG_PATH`) | ❌ |
-| Hot-reloads on change | ✅ every 10 s (default) | ❌ |
-| Uses for dispatch | ✅ MCP + A2A + agent card | ❌ |
+- **External (8080)** — client-facing: task create/list, get, cancel, SSE subscribe.
+  Reachable via the `asya-gateway-mesh-api` Service and (optionally) Ingress.
+- **Internal (8081)** — sidecar callbacks: publish status/FLY events, heartbeat
+  check. Reachable only in-cluster via the `asya-gateway-mesh-api-int` Service.
+  Sidecars learn this URL from the `x-asya-gateway-url` envelope header, stamped
+  by mesh-api from `ASYA_INTERNAL_URL`.
 
-The ConfigMap is the source of truth for *what flows exist*. It is seeded by
-Helm at deploy time and can be patched at runtime (e.g., via `kubectl patch` or
-`asya mcp expose`) without a pod restart.
+### Services
 
-**Database** — task and auth state (PostgreSQL):
+The chart renders four Services (release name `asya-gateway`):
 
-| | api pod | mesh pod |
-|---|---|---|
-| Creates tasks | ✅ (on MCP/A2A call) | ❌ |
-| Writes progress | ❌ | ✅ (via `/mesh/{id}/progress`) |
-| Writes final status | ❌ | ✅ (via `/mesh/{id}/final`) |
-| Reads task state | ✅ (GetTask, SSE, OAuth) | ✅ (SSE stream) |
-| Stores OAuth clients/tokens | ✅ (when OAuth enabled) | ❌ |
+| Service | Port | Type | Audience |
+|---------|------|------|----------|
+| `asya-gateway-mesh-api` | 8080 | ClusterIP | External clients (via Ingress) |
+| `asya-gateway-mesh-api-int` | 8081 | ClusterIP | Sidecars / crew (in-cluster only) |
+| `asya-gateway-mcp` | 8082 | ClusterIP | MCP clients (rendered when `mcp.enabled`) |
+| `asya-gateway-a2a` | 8083 | ClusterIP | A2A clients (rendered when `a2a.enabled`) |
 
-Both pods connect to the **same** database instance. The database is the shared
-coordination point: the api pod creates a task record, then mesh pod workers
-update it as actors report progress.
-
-The storage layer is abstracted internally. PostgreSQL is the provided
-implementation — it handles metadata and task state well for all current use
-cases. Additional backends may be added if specific requirements emerge. Note
-that this is distinct from the pluggable **transports** (SQS, RabbitMQ, Pub/Sub)
-and pluggable **state proxy connectors** (S3, GCS, Redis, NATS KV), which are
-designed for high-throughput data paths.
-
-Production deployments use **two Helm releases** from the same chart:
-
-```bash
-# External-facing API gateway (with Ingress)
-helm install asya-gateway deploy/helm-charts/asya-gateway/ \
-  --set mode=api \
-  -f gateway-values.yaml
-
-# Internal mesh gateway (ClusterIP only, no Ingress)
-helm install asya-gateway-mesh deploy/helm-charts/asya-gateway/ \
-  --set mode=mesh \
-  -f gateway-mesh-values.yaml
-```
-
-Both releases share the same container image and database. Sidecars
-and crew actors reach the mesh deployment via in-cluster DNS:
-`asya-gateway-mesh.<namespace>.svc.cluster.local`.
-
-**Gateway is stateful**: Requires a database (PostgreSQL) for task tracking and
-(when OAuth is enabled) for OAuth client/token storage.
+External exposure is via the Ingress (`ingress.enabled`), not a per-deployment
+LoadBalancer. The mesh-api-int Service has no Ingress and is unreachable from
+outside the cluster by design.
 
 ## Configuration
 
@@ -134,99 +124,99 @@ Configured via Helm values. Key sections:
 
 ```yaml
 # gateway-values.yaml
-mode: api  # api | mesh | testing
-config:
-  sqsRegion: "us-east-1"
-  postgresHost: "postgres.default.svc.cluster.local"
-  postgresDatabase: "asya_gateway"
-  postgresPasswordSecretRef:
-    name: postgres-secret
-    key: password
+
+stateProxy:
+  mesh:
+    backend: pg-kv   # pg-kv (PostgreSQL) | pvc-kv (local files / in-memory)
+
+# Only consulted by the pg-kv backend:
+database:
+  host: postgres.default.svc.cluster.local
+  port: 5432
+  name: asya_gateway
+  username: asya
+  existingSecret: postgres-secret   # key "password" by default
+  sslMode: require
+
+transports:
+  pubsub:
+    enabled: true     # exactly one of rabbitmq | sqs | pubsub
+    config:
+      projectId: my-project
+
+mcp:
+  enabled: true
+a2a:
+  enabled: true
+  auth:
+    apiKey: ""        # ASYA_A2A_API_KEY
+    jwt:
+      jwksURL: ""
+      issuer: ""
+      audience: ""
 ```
 
-Tool/skill registration is **ConfigMap-backed**: flows are declared in
-`flows.yaml`, mounted into the api pod, and hot-reloaded every 10 seconds (configurable via `ASYA_CONFIG_POLL_INTERVAL`) by a
-polling watcher (`toolstore.Watch`). Updating the ConfigMap is the only way to
-add, change, or remove an exposed tool or A2A skill — no restart is needed.
+Tool and skill registration is **ConfigMap-backed**. MCP tools are mounted into
+the mcp-adapter (`mcpTools` values) and A2A agents into the a2a-adapter
+(`a2aAgents` values). Each adapter hot-reloads its ConfigMap by polling every
+`ASYA_MCP_POLL_INTERVAL` / `ASYA_A2A_POLL_INTERVAL` (default `10s`). No restart is
+needed to add, change, or remove a tool or skill.
 
-The Helm chart creates an empty `gateway-flows` ConfigMap. After deployment,
-flows are registered by patching the ConfigMap (e.g., via `asya flow expose`
-or `kubectl patch`). No Helm upgrade is needed.
+**See**: [Gateway Setup Guide](../../setup/guide-gateway.md) for how flows are
+compiled into these ConfigMaps and registered.
 
 ## API Endpoints
 
-**See**: [Gateway API spec](../specs/gateway-api.md) for the full API reference with complete request/response schemas for all routes.
+**See**: [Gateway API spec](../specs/gateway-api.md) for full request/response schemas.
 
-
-
-Routes are split across the two deployments.
-
-### External API routes (`mode: api`)
-
-#### MCP endpoints
+### mesh-api external routes (port 8080)
 
 ```bash
-POST /mcp        # MCP Streamable HTTP transport (recommended)
-GET  /mcp/sse    # MCP SSE transport (for clients that require SSE)
-POST /tools/call # MCP tool invocation (REST convenience path)
+POST   /api/v1/mesh/            # Create task (returns task ID)
+GET    /api/v1/mesh/            # List tasks
+GET    /api/v1/mesh/{id}        # Get task status
+GET    /api/v1/mesh/{id}/events # Subscribe to SSE updates
+DELETE /api/v1/mesh/{id}        # Cancel task
+GET    /health                  # Liveness
+GET    /ready                   # Readiness (checks state-proxy reachability)
 ```
 
-Both `/mcp` and `/mcp/sse` are active transports — neither is deprecated. Use
-whichever your MCP client supports.
+The route prefix is configurable via `ASYA_MESH_API_PREFIX` (default `/api/v1`;
+set to `""` for unprefixed `/mesh/` routes).
 
-```bash
-GET  /.well-known/agent.json   # A2A Agent Card (public, no auth)
-POST /a2a/                     # A2A JSON-RPC endpoint
-```
-
-OAuth 2.1 endpoints (when `ASYA_MCP_OAUTH_ENABLED=true`):
-
-```bash
-GET  /.well-known/oauth-protected-resource    # RFC 9728 resource metadata
-GET  /.well-known/oauth-authorization-server  # RFC 8414 server metadata
-POST /oauth/register                          # Dynamic Client Registration
-GET  /oauth/authorize                         # Authorization Code endpoint
-POST /oauth/token                             # Token exchange and refresh
-```
-
-### Mesh routes (`mode: mesh`)
+### mesh-api internal routes (port 8081)
 
 Called exclusively by sidecars and crew actors within the cluster.
 
-#### Call Tool (REST, external api mode)
+```bash
+POST /api/v1/mesh/{id}/events  # Publish status + FLY events (sidecar)
+GET  /api/v1/mesh/{id}         # Heartbeat / pre-flight check (sidecar)
+```
+
+#### Publish events
 
 ```bash
-POST /tools/call
+POST /api/v1/mesh/{id}/events
 Content-Type: application/json
 
 {
-  "name": "text-processor",
-  "arguments": {
-    "text": "Hello world",
-    "model": "gpt-4"
-  }
+  "status": "running",
+  "current_actor_idx": 0,
+  "actors": ["prep", "infer", "post"]
 }
 ```
 
-Response (MCP CallToolResult):
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "{\"task_id\":\"5e6fdb2d...\",\"message\":\"Task created successfully\",\"status_url\":\"/mesh/5e6fdb2d...\",\"stream_url\":\"/mesh/5e6fdb2d.../stream\"}"
-    }
-  ],
-  "isError": false
-}
-```
+Both progress/status updates and ephemeral FLY events flow through this single
+endpoint. **Called by**: sidecars (per-actor status) and `x-sink` / `x-sump`
+(final status).
 
-See [Envelope Protocol](../specs/envelope.md) for more details on task statuses.
+⚠️ **FLY events are ephemeral** — never persisted. Clients connecting after task
+completion will NOT see historical FLY events.
 
-#### Get Task Status
+#### Get task status
 
 ```bash
-GET /tasks/{id}
+GET /api/v1/mesh/{id}
 ```
 
 Response:
@@ -234,232 +224,61 @@ Response:
 {
   "id": "5e6fdb2d-1d6b-4e91-baef-73e825434e7b",
   "status": "succeeded",
-  "message": "Task completed successfully",
-  "result": {"response": "Processed: Hello world"},
-  "progress_percent": 100,
-  "current_actor_idx": 2,
-  "current_actor_name": "postprocess",
-  "actors_completed": 3,
-  "total_actors": 3,
   "created_at": "2025-11-18T12:00:00Z",
-  "updated_at": "2025-11-18T12:01:30Z"
+  "updated_at": "2025-11-18T12:01:30Z",
+  "data": {"result": {"response": "Processed: Hello world"}}
 }
 ```
 
-#### Stream Task Updates (SSE)
+See [Envelope Protocol](../specs/envelope.md) for task statuses.
+
+#### Subscribe to updates (SSE)
 
 ```bash
-GET /mesh/{id}/stream
+GET /api/v1/mesh/{id}/events
 Accept: text/event-stream
 ```
 
-Internal mesh endpoint for streaming progress and FLY events. For external API access, use `GET /stream/{id}` on the API gateway.
-
 **Features**:
 
-- Sends historical progress and status updates first (no missed progress)
+- Sends historical status updates first (no missed progress)
 - Streams real-time updates as they occur
-- Broadcasts ephemeral FLY events via PG LISTEN/NOTIFY for cross-process delivery
+- Relays ephemeral FLY events to connected subscribers
 - Keepalive comments every 15 seconds
-- Auto-closes on final status (`succeeded` or `failed`)
+- Auto-closes on terminal status (`succeeded`, `failed`, `canceled`)
 
-⚠️ **FLY events are ephemeral** — not persisted to the database. Clients connecting after task completion will NOT see historical FLY events.
-
-Stream events (TaskUpdate):
-```
-event: update
-data: {"id":"task-123","status":"running","progress_percent":10,"current_actor_idx":0,"actor_state":"received","actor":"preprocess","actors":["preprocess","infer","post"],"message":"Actor preprocess: received","timestamp":"2025-11-18T12:00:15Z"}
-
-event: update
-data: {"id":"task-123","status":"running","progress_percent":33,"current_actor_idx":0,"actor_state":"completed","actor":"preprocess","actors":["preprocess","infer","post"],"message":"Actor preprocess: completed","timestamp":"2025-11-18T12:00:20Z"}
-
-event: update
-data: {"id":"task-123","status":"running","progress_percent":66,"current_actor_idx":1,"actor_state":"completed","actor":"infer","actors":["preprocess","infer","post"],"message":"Actor infer: completed","timestamp":"2025-11-18T12:01:00Z"}
-
-event: update
-data: {"id":"task-123","status":"succeeded","progress_percent":100,"result":{...},"message":"Task completed successfully","timestamp":"2025-11-18T12:01:30Z"}
-```
-
-**TaskUpdate fields**:
-
-- `id`: Task ID
-- `status`: Task status (`pending`, `running`, `succeeded`, `failed`)
-- `progress_percent`: Progress 0-100 (omitted if not a progress update)
-- `current_actor_idx`: Current actor index (0-based, omitted for final states)
-- `actor_state`: Actor processing state (`received`, `processing`, `completed`)
-- `actor`: Current actor name (omitted for final states)
-- `actors`: Full route (may be modified via VFS)
-- `message`: Human-readable status message
-- `result`: Final result (only for `succeeded` status)
-- `error`: Error message (only for `failed` status)
-- `timestamp`: When this update occurred
-
-#### Check Task Active
+### MCP routes (mcp-adapter, port 8082)
 
 ```bash
-GET /mesh/{id}/active
+POST /mcp        # MCP Streamable HTTP transport (recommended)
+GET  /mcp/sse    # MCP SSE transport (for clients that require SSE)
+GET  /health     # Liveness
 ```
 
-**Used by**: Actors to verify task hasn't timed out
-
-Response (active):
-```json
-{"active": true}
-```
-
-Response (inactive - HTTP 410 Gone):
-```json
-{"active": false}
-```
-
-### Mesh endpoints (Sidecar/Crew, `mode: mesh`)
-
-#### Report Progress
+### A2A routes (a2a-adapter, port 8083)
 
 ```bash
-POST /mesh/{id}/progress
-Content-Type: application/json
-
-{
-  "actors": ["prep", "infer", "post"],
-  "current_actor_idx": 0,
-  "status": "completed"
-}
+POST /a2a/                     # A2A JSON-RPC endpoint
+GET  /.well-known/agent.json   # A2A Agent Card (public, no auth)
+GET  /health                   # Liveness
 ```
-
-**Called by**: Sidecars at three points per actor (`received`, `processing`, `completed`)
-
-**Progress formula**: `(actor_idx * 100 + status_weight) / total_actors`
-- `received` = 10, `processing` = 50, `completed` = 100
-
-**Unknown task IDs**: Progress updates for tasks not found in the store are
-silently accepted (200 OK). This is expected for direct-SQS envelopes that bypass
-gateway task creation. Infrastructure errors (e.g., database failures) still
-return 500.
-
-Response:
-```json
-{"status": "ok", "progress_percent": 33.3}
-```
-
-#### Report Final Status
-
-```bash
-POST /mesh/{id}/final
-Content-Type: application/json
-
-{
-  "id": "task-123",
-  "status": "succeeded",
-  "result": {...}
-}
-```
-
-**Called by**: `x-sink` (success) or `x-sump` (failure) crew actors
-
-#### Create Fanout Task
-
-```bash
-POST /tasks
-Content-Type: application/json
-
-{
-  "id": "task-123-1",
-  "parent_id": "task-123",
-  "actors": ["prep", "infer"],
-  "current": 1
-}
-```
-
-**Called by**: Sidecars when runtime returns array (fan-out)
-
-**Fanout ID semantics**:
-
-- Index 0: Original ID (`task-123`)
-- Index 1+: Suffixed (`task-123-1`, `task-123-2`)
-- All children have `parent_id` for traceability
-
-### Health Check
-
-```bash
-GET /health
-```
-
-Response: `OK`
-
-## Flow Examples
-
-Flows are declared in `flows.yaml` (mounted as a ConfigMap). Each entry is a
-`FlowConfig` that maps a name to an actor pipeline and declares whether it is
-exposed as an MCP tool, an A2A skill, or both.
-
-**Single-actor MCP tool**:
-```yaml
-flows:
-- name: hello
-  entrypoint: hello-actor
-  description: Say hello
-  mcp:
-    inputSchema:
-      type: object
-      properties:
-        who:
-          type: string
-          description: Name to greet
-      required: [who]
-```
-
-**Multi-actor pipeline exposed as both MCP and A2A**:
-```yaml
-flows:
-- name: image-enhance
-  entrypoint: download-image
-  route_next: [enhance, upload]
-  description: Enhance image quality
-  timeout: 120
-  mcp:
-    inputSchema:
-      type: object
-      properties:
-        image_url:
-          type: string
-          description: URL of image to enhance
-        quality:
-          type: string
-          description: "Target quality: low | medium | high"
-      required: [image_url]
-  a2a: {}
-```
-
-**Fields**:
-
-| Field | Required | Description |
-|---|---|---|
-| `name` | ✅ | Unique flow name; becomes the MCP tool name and A2A skill name |
-| `entrypoint` | ✅ | First actor in the pipeline (queue name without `asya-<ns>-` prefix) |
-| `route_next` | ❌ | Ordered list of subsequent actors |
-| `description` | ❌ | Human-readable description surfaced in tool/skill listings |
-| `timeout` | ❌ | Max seconds to wait for completion (default: no limit) |
-| `mcp` | ❌ | Present → exposed as MCP tool; `inputSchema` is the JSON Schema for arguments |
-| `a2a` | ❌ | Present → exposed as A2A skill |
 
 ## Authentication & Security
 
-The gateway implements protocol-native authentication on external routes and
-network-level isolation for mesh routes. No auth code runs on mesh routes —
-they are unreachable from outside the cluster by design.
+Authentication is applied per adapter. mesh-api internal routes carry no auth
+code — they are protected by network isolation (ClusterIP only).
 
-| Route group | Auth mechanism |
-|-------------|---------------|
-| A2A (`/a2a/`) | API key (`X-API-Key`) or JWT Bearer — configured via `ASYA_A2A_*` env vars |
-| MCP (`/mcp`, `/mcp/sse`, `/tools/call`) | API key Bearer or OAuth 2.1 token — configured via `ASYA_MCP_*` env vars |
-| Mesh (`/mesh/…`) | None — ClusterIP only, unreachable externally |
-| Well-known + health | Always public |
+| Route group | Container | Auth mechanism |
+|-------------|-----------|---------------|
+| A2A (`/a2a/`) | a2a-adapter | API key (`X-API-Key`) or JWT Bearer — `ASYA_A2A_*` env vars |
+| A2A Agent Card + health | a2a-adapter | Always public |
+| MCP (`/mcp`, `/mcp/sse`) | mcp-adapter | None currently wired |
+| mesh-api (`/api/v1/mesh/…`) | mesh-api | None — internal port is ClusterIP only |
 
 ### A2A Authentication
 
 Two schemes are supported with OR semantics — a request is authenticated if
-either check passes:
+either check passes.
 
 **API Key**
 
@@ -467,8 +286,7 @@ either check passes:
 X-API-Key: <value>
 ```
 
-Configured via `ASYA_A2A_API_KEY`. When set, the header value must match
-exactly (constant-time comparison).
+Configured via `ASYA_A2A_API_KEY`. When set, the header value must match exactly.
 
 **JWT Bearer**
 
@@ -477,123 +295,35 @@ Authorization: Bearer <JWT>
 ```
 
 Configured via `ASYA_A2A_JWT_JWKS_URL` + `ASYA_A2A_JWT_ISSUER` +
-`ASYA_A2A_JWT_AUDIENCE`. The gateway fetches the JWKS from the configured URL
-and validates the token signature, issuer, and audience claims.
+`ASYA_A2A_JWT_AUDIENCE`. The adapter fetches the JWKS from the configured URL and
+validates the token signature, issuer, and audience claims.
 
-When neither `ASYA_A2A_API_KEY` nor `ASYA_A2A_JWT_JWKS_URL` is set, A2A auth
-is disabled (all requests pass). This is the default for local development.
-
-The public Agent Card at `/.well-known/agent.json` advertises the configured
-schemes. Authenticated clients access only their own tasks — the gateway must
-not reveal the existence of tasks belonging to other clients.
-
-### MCP Authentication
-
-MCP auth is applied to `/mcp`, `/mcp/sse`, and `/tools/call`. Two modes are
-mutually exclusive:
-
-**API Key (simple, non-spec-compliant)**
-
-```
-Authorization: Bearer <static-key>
-```
-
-Set `ASYA_MCP_API_KEY` to a shared secret. Suitable for internal tooling
-(`asya-lab` CLI, known MCP hosts) where full OAuth is not needed.
-
-When `ASYA_MCP_API_KEY` is empty, MCP auth is disabled.
-
-**OAuth 2.1 (full MCP spec compliance)**
-
-Set `ASYA_MCP_OAUTH_ENABLED=true` plus `ASYA_MCP_OAUTH_ISSUER` and
-`ASYA_MCP_OAUTH_SECRET`. The gateway acts as its own authorization server,
-issuing HMAC-SHA256 JWTs. PostgreSQL is required (`ASYA_DATABASE_URL`).
-
-Scopes (issued but not yet enforced per-endpoint):
-
-| Scope | Intended permission |
-|-------|-------------------|
-| `mcp:invoke` | Call tools, send messages |
-| `mcp:read` | List tools, read task state |
-
-Scopes are issued into access tokens and stored in the database. However,
-`MCPAuthMiddleware` currently only validates that a token is authentic (signature,
-`iss`, `aud`, `exp`) — it does **not** check that the token's scope is sufficient
-for the specific operation being requested.
-
-OAuth 2.1 endpoints (when `ASYA_MCP_OAUTH_ENABLED=true`):
-
-```bash
-GET  /.well-known/oauth-protected-resource    # RFC 9728 resource metadata
-GET  /.well-known/oauth-authorization-server  # RFC 8414 server metadata
-POST /oauth/register                          # Dynamic Client Registration
-GET  /oauth/authorize                         # Authorization Code endpoint
-POST /oauth/token                             # Token exchange and refresh
-```
-
-PKCE (`code_challenge_method=S256`) is required for all clients.
-
-Dynamic Client Registration (`/oauth/register`) is public by default. To restrict
-it, set `ASYA_MCP_OAUTH_REGISTRATION_TOKEN` — callers must then supply
-`Authorization: Bearer <registration-token>` to register.
+When neither `ASYA_A2A_API_KEY` nor `ASYA_A2A_JWT_JWKS_URL` is set, A2A auth is
+disabled (all requests pass). This is the default for local development. The
+public Agent Card at `/.well-known/agent.json` advertises the configured schemes.
 
 ### Mesh Security
 
-Mesh routes carry no authentication code. Security is enforced at the network
-layer:
+The mesh-api internal port (8081) carries no authentication code. Security is
+enforced at the network layer:
 
-- `asya-gateway-mesh` K8s Service is `ClusterIP` — no Ingress, no NodePort.
+- `asya-gateway-mesh-api-int` is a `ClusterIP` Service — no Ingress, no NodePort.
   It is physically unreachable from outside the cluster.
 - Sidecars and crew actors reach it via in-cluster DNS:
-  `asya-gateway-mesh.<namespace>.svc.cluster.local`.
+  `asya-gateway-mesh-api-int.<namespace>.svc.cluster.local:8081`.
 
-For defence in depth, add a K8s NetworkPolicy restricting ingress to actor pods:
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: gateway-mesh-ingress
-spec:
-  podSelector:
-    matchLabels:
-      app: asya-gateway-mesh
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              asya.sh/component: actor
-      ports:
-        - port: 8080
-```
-
-Alternatively, enable a service mesh (Istio/Linkerd) for automatic mTLS between
-all pods with zero Asya code changes.
+For defence in depth, add a K8s NetworkPolicy restricting ingress to actor pods,
+or enable a service mesh (Istio/Linkerd) for automatic mTLS.
 
 ### Environment Variables
 
-All auth-related environment variables:
-
-| Variable | Default | Required | Description |
-|----------|---------|----------|-------------|
-| `ASYA_GATEWAY_MODE` | — | Yes | `api`, `mesh`, or `testing` |
-| `ASYA_DATABASE_URL` | `""` | For OAuth 2.1 | PostgreSQL DSN; required when `ASYA_MCP_OAUTH_ENABLED=true` |
-| **A2A** | | | |
-| `ASYA_A2A_API_KEY` | `""` | No | Static API key; auth disabled when empty |
-| `ASYA_A2A_JWT_JWKS_URL` | `""` | No | JWKS endpoint URL for JWT validation |
-| `ASYA_A2A_JWT_ISSUER` | `""` | With JWKS | Expected `iss` claim |
-| `ASYA_A2A_JWT_AUDIENCE` | `""` | With JWKS | Expected `aud` claim |
-| **MCP Phase 2** | | | |
-| `ASYA_MCP_API_KEY` | `""` | No | Static Bearer token; auth disabled when empty |
-| **MCP Phase 3 (OAuth 2.1)** | | | |
-| `ASYA_MCP_OAUTH_ENABLED` | `false` | No | Set to `true` to enable OAuth 2.1 |
-| `ASYA_MCP_OAUTH_ISSUER` | `""` | Yes (OAuth) | Issuer URL embedded in tokens and metadata |
-| `ASYA_MCP_OAUTH_SECRET` | `""` | Yes (OAuth) | HMAC-SHA256 signing key for access tokens |
-| `ASYA_MCP_OAUTH_TOKEN_TTL` | `3600` | No | Access token lifetime in seconds |
-| `ASYA_MCP_OAUTH_REGISTRATION_TOKEN` | `""` | No | Bearer token protecting `/oauth/register`; empty = open |
+Per-component variables are documented in the
+[Environment Variables reference](../env-vars.md) — see the `asya-mesh-api`,
+`mcp-adapter`, and `a2a-adapter` sections.
 
 ## Using MCP tools
-**See**: [Quickstart](../../setup/start-quickstart.md) for instructions how to test MCP locally.
+
+**See**: [Quickstart](../../setup/start-quickstart.md) for instructions on testing MCP locally.
 
 ## Deployment Helm Charts
 

--- a/docs/reference/credentials.md
+++ b/docs/reference/credentials.md
@@ -23,17 +23,14 @@ crossplane-system/              keda/                   $NS (actor namespace)
 | (or: WI on provider KSA) |   +-------------------+   |   credentials.json               |
 +---------------------------+                           |   Used by: TriggerAuthentication  |
                                                         |                                  |
-                                                        | asya-gateway-postgresql (Secret)  |
-                                                        |   password                       |
-                                                        |   Used by: gateway init container |
-                                                        |                                  |
                                                         | asya-gateway-db (Secret)          |
-                                                        |   database-url (DSN)             |
-                                                        |   Used by: gateway main container |
+                                                        |   password (pg-kv backend only)  |
+                                                        |   Used by: state-proxy-mesh      |
+                                                        |   (not needed for pvc-kv)        |
                                                         |                                  |
                                                         | asya-gateway-auth (Secret)        |
-                                                        |   a2a-api-key, mcp-api-key       |
-                                                        |   Used by: gateway (env)         |
+                                                        |   a2a-api-key                    |
+                                                        |   Used by: a2a-adapter (env)     |
                                                         |                                  |
                                                         | default KSA (ServiceAccount)      |
                                                         |   annotation: iam.gke.io/gcp-sa  |
@@ -60,9 +57,8 @@ crossplane-system/              keda/                   $NS (actor namespace)
 | `gcp-creds` | `crossplane-system` | `credentials.json` | Manual (`kubectl create secret`) | Crossplane GCP provider | `gcpProviderConfig.secretRef.*` |
 | `gcp-keda-secret` | `$NS` (actor namespace) | `credentials.json` | Manual | KEDA `TriggerAuthentication` (per-actor, created by composition) | `pubsub.keda.secretRef.name` |
 | `asya-runtime` | `$NS` | `asya_runtime.py` | `asya-crossplane` chart (ConfigMap) | All actor pods (volume mount) | Automatic |
-| `asya-gateway-postgresql` | `$NS` | `password` | Manual or gateway chart | Gateway init container (`PGPASSWORD`) | `externalDatabase.existingSecret` |
-| `asya-gateway-db` | `$NS` | `database-url` | Gateway chart (auto) or manual | Gateway main container (`ASYA_DATABASE_URL`) | Auto-generated from `externalDatabase.*` |
-| `asya-gateway-auth` | `$NS` | `a2a-api-key`, `mcp-api-key` | Manual (`openssl rand`) | Gateway (`ASYA_A2A_API_KEY`, `ASYA_MCP_API_KEY`) | Via `env[].valueFrom.secretKeyRef` |
+| `asya-gateway-db` | `$NS` | `password` | Manual (pg-kv only) | state-proxy-mesh sidecar (`DB_PASSWORD` → `STATE_PROXY_PG_URL`) | `database.existingSecret` (key `database.existingSecretKey`, default `password`) |
+| `asya-gateway-auth` | `$NS` | `a2a-api-key` | Manual (`openssl rand`) | a2a-adapter (`ASYA_A2A_API_KEY`) | `a2a.auth.apiKey` |
 
 ### Workload Identity Bindings
 
@@ -158,16 +154,17 @@ If an AsyncActor is created before `defaultCompositionRef` is set on the XRD, it
 up whatever composition Crossplane selects (often alphabetically). Changing the XRD
 default later does NOT affect existing actors. Delete and recreate them.
 
-**Gateway needs two DB secrets.**
-The `asya-gateway-postgresql` secret holds the raw password (used by the init container
-for `psql` health checks). The `asya-gateway-db` secret holds the full DSN (used by
-the main container for `ASYA_DATABASE_URL`). When using `externalDatabase.existingSecret`,
-the chart reads the password for init but still needs the DSN secret.
+**The gateway DB secret is only needed with the `pg-kv` backend.**
+With `stateProxy.mesh.backend: pg-kv`, the state-proxy-mesh sidecar reads the DB
+password from `database.existingSecret` (key `database.existingSecretKey`, default
+`password`) as `DB_PASSWORD` and assembles the connection string itself — there is no
+separate DSN secret and no init container. With the `pvc-kv` backend the gateway needs
+no database and no DB secret at all.
 
-**PostgreSQL password is set at initdb time.**
-The PG StatefulSet reads `POSTGRES_PASSWORD` from the secret on first start and stores
-it in the PVC. If the secret is later changed, PG still uses the old password. Fix with
-`ALTER USER asya WITH PASSWORD '...'` inside the running pod.
+**PostgreSQL password is set at initdb time (in-cluster PG only).**
+If you run your own in-cluster PostgreSQL, it reads `POSTGRES_PASSWORD` from the secret
+on first start and stores it in the PVC. If the secret is later changed, PG still uses
+the old password. Fix with `ALTER USER asya WITH PASSWORD '...'` inside the running pod.
 
 **Actor pods use WI, not JSON keys.**
 The `sidecar.gcpCredsSecret` helm value mounts a secret via `envFrom`. But Kubernetes

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -119,69 +119,16 @@ Source: `src/asya-runtime/asya_runtime.py`
 
 ## asya-gateway
 
-Source: `src/asya-gateway/cmd/gateway/main.go`
+The gateway is no longer a single binary with an `ASYA_GATEWAY_MODE` switch. It is
+split into separate containers, all built from the one `asya-gateway` image:
 
-### Core
+- **asya-mesh-api** — core HTTP server (see section below)
+- **mcp-adapter** — MCP HTTP adapter (see section below)
+- **a2a-adapter** — A2A JSON-RPC adapter (see section below)
+- **state-proxy-mesh** — task/mesh state connector (`pg-kv` or `pvc-kv`, see below)
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ASYA_GATEWAY_MODE` | Deployment mode: `api`, `mesh`, or `testing` | _(unset)_ |
-| `ASYA_GATEWAY_PORT` | HTTP listen port | `8080` |
-| `ASYA_DATABASE_URL` | PostgreSQL connection string | `""` |
-| `ASYA_CONFIG_PATH` | Path to `flows.yaml` ConfigMap mount | _(unset)_ |
-| `ASYA_CONFIG_POLL_INTERVAL` | How often to poll the ConfigMap for changes | `10s` |
-| `ASYA_NAMESPACE` | Kubernetes namespace for queue name prefix | `default` |
-| `ASYA_LOG_LEVEL` | Log level | `INFO` |
-| `ASYA_PERSISTENCE_MOUNT` | Mount path for file-based persistence | _(unset)_ |
-
-### Transport (same as sidecar)
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ASYA_RABBITMQ_URL` | RabbitMQ connection URL | `""` |
-| `ASYA_RABBITMQ_EXCHANGE` | RabbitMQ exchange | `asya` |
-| `ASYA_RABBITMQ_POOL_SIZE` | RabbitMQ connection pool size | `20` |
-| `ASYA_SQS_ENDPOINT` | SQS endpoint URL | `""` |
-| `ASYA_SQS_REGION` | SQS region | `us-east-1` |
-| `ASYA_SQS_VISIBILITY_TIMEOUT` | SQS visibility timeout | `300` |
-| `ASYA_SQS_WAIT_TIME_SECONDS` | SQS long-poll wait time | `20` |
-| `ASYA_PUBSUB_PROJECT_ID` | GCP Pub/Sub project ID | `""` |
-| `ASYA_PUBSUB_ENDPOINT` | Pub/Sub emulator endpoint | `""` |
-
-### Database connection pool
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ASYA_DB_MAX_CONNS` | Maximum PostgreSQL connections | `10` |
-| `ASYA_DB_MIN_CONNS` | Minimum PostgreSQL connections | `2` |
-| `ASYA_DB_MAX_CONN_LIFETIME` | Maximum connection lifetime | `1h` |
-| `ASYA_DB_MAX_CONN_IDLE_TIME` | Maximum connection idle time | `30m` |
-
-### A2A configuration
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ASYA_A2A_API_KEY` | API key for A2A authentication | _(unset)_ |
-| `ASYA_A2A_JWT_JWKS_URL` | JWKS URL for JWT validation | _(unset)_ |
-| `ASYA_A2A_JWT_ISSUER` | Expected JWT issuer | _(unset)_ |
-| `ASYA_A2A_JWT_AUDIENCE` | Expected JWT audience | _(unset)_ |
-| `ASYA_A2A_NAME` | Agent card display name | `Asya Gateway` |
-| `ASYA_A2A_DESCRIPTION` | Agent card description | `AI Actor Mesh for distributed agentic workloads` |
-| `ASYA_A2A_VERSION` | Agent card version | `1.0.0` |
-| `ASYA_A2A_PUBLIC_URL` | Public base URL for the agent card | `""` |
-| `ASYA_A2A_PROVIDER_ORG` | Agent card provider organization | `Asya` |
-| `ASYA_A2A_PROVIDER_URL` | Agent card provider URL | `https://asya.sh` |
-
-### MCP configuration
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ASYA_MCP_API_KEY` | API key for MCP authentication | _(unset)_ |
-| `ASYA_MCP_OAUTH_ENABLED` | Enable OAuth 2.1 for MCP | _(unset)_ |
-| `ASYA_MCP_OAUTH_ISSUER` | OAuth issuer URL | _(unset)_ |
-| `ASYA_MCP_OAUTH_SECRET` | OAuth HMAC signing secret | _(unset)_ |
-| `ASYA_MCP_OAUTH_TOKEN_TTL` | OAuth access token TTL (seconds) | `3600` |
-| `ASYA_MCP_OAUTH_REGISTRATION_TOKEN` | Bearer token for dynamic client registration | _(unset)_ |
+There is no shared `asya-gateway` env-var set; each container has its own. See the
+[Gateway component reference](components/core-gateway.md) for the container split.
 
 ---
 
@@ -200,10 +147,12 @@ Unix socket.
 |----------|-------------|---------|
 | `ASYA_MESH_EXTERNAL_PORT` | External API listen port | _(required)_ |
 | `ASYA_MESH_INTERNAL_PORT` | Internal sidecar listen port | _(required)_ |
-| `ASYA_STATEPROXY_SOCKET` | Unix socket path to pg-kv | _(required)_ |
+| `ASYA_STATEPROXY_SOCKET` | Unix socket path to the state-proxy (pg-kv or pvc-kv) | _(required)_ |
 | `ASYA_INTERNAL_URL` | URL sidecars use for callbacks (stamped as `x-asya-gateway-url`) | _(required)_ |
+| `ASYA_QUEUE_TRANSPORT` | Queue backend: `rabbitmq`, `sqs`, or `pubsub` | _(required)_ |
 | `ASYA_NAMESPACE` | Kubernetes namespace for queue name prefix | `""` |
 | `ASYA_MESH_API_PREFIX` | HTTP route prefix for mesh API (e.g. `/api/v1`, or `""` for unprefixed) | `/api/v1` |
+| `ASYA_BACKSTOP_INTERVAL` | Poll cadence for the SLA backstop reaper (Go duration) | `5s` |
 | `ASYA_LOG_LEVEL` | Log level | _(unset)_ |
 
 ### Transport (same as gateway)
@@ -220,18 +169,37 @@ Uses the same queue transport env vars as asya-gateway (`ASYA_QUEUE_TRANSPORT`,
 
 ---
 
-## pg-kv
+## state-proxy-mesh (pg-kv — default)
 
 Source: `src/asya-state-proxy/go/cmd/pg-kv/main.go`
 
-Go-based PostgreSQL state proxy connector. Runs as a sidecar alongside
-asya-mesh-api, serving KV operations and Mango-style queries over a Unix socket.
+Default mesh state backend. Go-based PostgreSQL connector that runs as a sidecar
+alongside asya-mesh-api, serving KV operations and Mango-style queries over a Unix
+socket. Selected by `stateProxy.mesh.backend: pg-kv` in the gateway chart.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CONNECTOR_SOCKET` | Unix socket path | _(required)_ |
 | `STATE_PROXY_PG_URL` | PostgreSQL connection string | _(required)_ |
 | `STATE_PROXY_PG_INDEXES` | Comma-separated expression index specs (e.g. `status,(deadline_at)::timestamptz`) | `""` |
+
+---
+
+## state-proxy-mesh (pvc-kv — no PostgreSQL)
+
+Source: `src/asya-state-proxy/go/cmd/pvc-kv/main.go`
+
+Alternative mesh state backend that needs **no external database**. Stores task
+state as JSON files on a PVC (or in memory) and queries them in-process with
+DuckDB. Selected by `stateProxy.mesh.backend: pvc-kv` (requires `replicaCount: 1`).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CONNECTOR_SOCKET` | Unix socket path | _(required)_ |
+| `PVC_KV_MODE` | Storage mode: `pvc` (files) or `inmem` (in-memory) | _(required)_ |
+| `PVC_KV_BASE_DIR` | Storage root directory | _(required for `pvc` mode)_ |
+| `PVC_KV_PARTITION` | `"true"` enables `active/` + `archive/` subdirs | `false` |
+| `PVC_KV_ARCHIVE_STATUSES` | Comma-separated statuses to archive on delete | `""` |
 
 ---
 

--- a/docs/setup/guide-pause-resume.md
+++ b/docs/setup/guide-pause-resume.md
@@ -243,10 +243,11 @@ mc ls local/asya-checkpoints/paused/
 
 ### Resume fails with "task not paused"
 
-The task must be in `paused` status. Check task status:
+The task must be in `paused` status. Check task status via the mesh-api external
+service:
 
 ```bash
-curl http://<gateway-api>/mesh/<task-id>
+curl http://asya-gateway-mesh-api.<namespace>.svc.cluster.local:8080/api/v1/mesh/<task-id>
 ```
 
 ---

--- a/docs/setup/start-gcp-gke.md
+++ b/docs/setup/start-gcp-gke.md
@@ -314,7 +314,6 @@ helm install asya-crossplane asya/asya-crossplane --version $ASYA_VERSION \
   --set gcpProviderConfig.secretRef.name=gcp-creds \
   --set gcpProviderConfig.secretRef.key=credentials.json \
   --set sidecar.gcpProjectId=$PROJECT \
-  --set sidecar.gatewayURL=http://asya-gateway-mesh.${NS}.svc.cluster.local \
   --set functions.flavorsEnabled=true \
   --set keda.authProvider=secret \
   --set pubsub.keda.secretRef.name=gcp-keda-secret \
@@ -322,9 +321,9 @@ helm install asya-crossplane asya/asya-crossplane --version $ASYA_VERSION \
   --wait --timeout=10m
 ```
 
-> **`sidecar.gatewayURL`** must be the base URL with **no path suffix**. The sidecar progress
-> reporter appends `/health`, `/mesh`, `/mesh/{id}/final` etc. automatically. Setting it to
-> `http://host/mesh` produces double-path URLs and silently breaks task completion callbacks.
+> Sidecars no longer need a gateway URL at install time. The mesh-api stamps its
+> internal callback URL (`asya-gateway-mesh-api-int`) into the `x-asya-gateway-url`
+> envelope header on every task it creates, and the sidecar reads it from there.
 
 Wait for the GCP Pub/Sub provider to become healthy:
 
@@ -399,14 +398,62 @@ helm install asya-crew asya/asya-crew --version $ASYA_VERSION \
 
 ### asya-gateway
 
-The gateway requires PostgreSQL for task state. For production use Cloud SQL, AlloyDB,
-or another managed service. For a quick in-cluster instance:
+The gateway is one image (`asya-gateway`) that runs as several containers in a
+single pod: `mesh-api` (core HTTP), optional `mcp-adapter` and `a2a-adapter`, and a
+`state-proxy-mesh` sidecar. Task state is pluggable via `stateProxy.mesh.backend`:
+
+- **`pvc-kv`** — local files / in-memory, **no database**. Simplest to start with
+  (requires `replicaCount: 1`).
+- **`pg-kv`** _(default)_ — PostgreSQL. For production use Cloud SQL, AlloyDB, or
+  another managed service.
+
+The gateway publishes envelopes to Pub/Sub, so its Service Account needs Pub/Sub
+publish access. Bind the gateway SA to the `asya-actor` GCP SA via Workload Identity
+(the chart creates an SA named `asya-gateway` by default):
+
+```bash
+kubectl annotate serviceaccount asya-gateway -n $NS \
+  iam.gke.io/gcp-service-account=asya-actor@${PROJECT}.iam.gserviceaccount.com \
+  --overwrite 2>/dev/null || true
+
+gcloud iam service-accounts add-iam-policy-binding \
+  asya-actor@${PROJECT}.iam.gserviceaccount.com \
+  --role=roles/iam.workloadIdentityUser \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${NS}/asya-gateway]" \
+  --condition=None --project=$PROJECT
+```
+
+> If the SA does not exist yet, install the gateway first (below), then run the
+> annotate/bind commands and `kubectl rollout restart deployment/asya-gateway -n $NS`.
+
+#### Option A: pvc-kv (no PostgreSQL)
+
+```bash
+helm install asya-gateway asya/asya-gateway --version $ASYA_VERSION \
+  --namespace=$NS \
+  --set replicaCount=1 \
+  --set stateProxy.mesh.backend=pvc-kv \
+  --set transports.pubsub.enabled=true \
+  --set "transports.pubsub.config.projectId=${PROJECT}" \
+  --set mcp.enabled=true \
+  --set a2a.enabled=true \
+  --set a2a.auth.apiKey=$(kubectl get secret asya-gateway-auth -n $NS \
+        -o jsonpath='{.data.a2a-api-key}' | base64 -d) \
+  --set ingress.enabled=true \
+  --set ingress.host=<your-gateway-host> \
+  --wait --timeout=5m
+```
+
+#### Option B: pg-kv (PostgreSQL)
+
+For PostgreSQL state, point the `database.*` values at your instance. For a quick
+in-cluster instance, create a Secret and StatefulSet first:
 
 <details>
 <summary>In-cluster PostgreSQL (click to expand)</summary>
 
 ```bash
-kubectl create secret generic asya-gateway-postgresql \
+kubectl create secret generic asya-gateway-db \
   --namespace=$NS \
   --from-literal=password=$(openssl rand -hex 16)
 
@@ -437,7 +484,7 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: asya-gateway-postgresql
+              name: asya-gateway-db
               key: password
         volumeMounts:
         - name: data
@@ -466,75 +513,63 @@ EOF
 
 </details>
 
-Then install the gateway, referencing the secret directly:
-
 ```bash
 helm install asya-gateway asya/asya-gateway --version $ASYA_VERSION \
   --namespace=$NS \
-  --set image.tag=$ASYA_VERSION \
+  --set stateProxy.mesh.backend=pg-kv \
+  --set database.host=asya-gateway-postgresql \
+  --set database.port=5432 \
+  --set database.name=asya_gateway \
+  --set database.username=asya \
+  --set database.existingSecret=asya-gateway-db \
+  --set database.existingSecretKey=password \
   --set transports.pubsub.enabled=true \
   --set "transports.pubsub.config.projectId=${PROJECT}" \
-  --set postgresql.enabled=false \
-  --set externalDatabase.host=asya-gateway-postgresql \
-  --set externalDatabase.port=5432 \
-  --set externalDatabase.database=asya_gateway \
-  --set externalDatabase.username=asya \
-  --set externalDatabase.existingSecret=asya-gateway-postgresql \
-  --set externalDatabase.existingSecretKey=password \
-  --set "volumes[0].name=gcp-creds" \
-  --set "volumes[0].secret.secretName=asya-actor-creds" \
-  --set "volumeMounts[0].name=gcp-creds" \
-  --set "volumeMounts[0].mountPath=/secrets/gcp" \
-  --set "volumeMounts[0].readOnly=true" \
-  --set "env[0].name=GOOGLE_APPLICATION_CREDENTIALS" \
-  --set "env[0].value=/secrets/gcp/sa-key.json" \
-  --set "env[1].name=ASYA_A2A_API_KEY" \
-  --set "env[1].valueFrom.secretKeyRef.name=asya-gateway-auth" \
-  --set "env[1].valueFrom.secretKeyRef.key=a2a-api-key" \
-  --set "env[2].name=ASYA_MCP_API_KEY" \
-  --set "env[2].valueFrom.secretKeyRef.name=asya-gateway-auth" \
-  --set "env[2].valueFrom.secretKeyRef.key=mcp-api-key" \
-  --set service.type=LoadBalancer \
+  --set mcp.enabled=true \
+  --set a2a.enabled=true \
+  --set a2a.auth.apiKey=$(kubectl get secret asya-gateway-auth -n $NS \
+        -o jsonpath='{.data.a2a-api-key}' | base64 -d) \
+  --set ingress.enabled=true \
+  --set ingress.host=<your-gateway-host> \
   --wait --timeout=5m
 ```
 
 ### Gateway security
 
-`asya-gateway` is deployed as two separate Deployments from the same binary:
+The gateway exposes four ClusterIP Services from the single pod:
 
-| Deployment | Service | Reachable from | Auth |
+| Service | Port | Reachable from | Auth |
 |---|---|---|---|
-| `asya-gateway-api` | LoadBalancer (port 80) | External clients, LLMs, AI agents | API key / JWT Bearer |
-| `asya-gateway-mesh` | ClusterIP | Actor sidecars only (in-cluster DNS) | None — network isolation |
+| `asya-gateway-mesh-api` | 8080 | External clients (via Ingress) | None on mesh-api itself |
+| `asya-gateway-mesh-api-int` | 8081 | Actor sidecars only (in-cluster DNS) | None — network isolation |
+| `asya-gateway-mcp` | 8082 | MCP clients (via Ingress) | None currently wired |
+| `asya-gateway-a2a` | 8083 | A2A clients (via Ingress) | API key / JWT Bearer |
 
-**Protected routes** (`asya-gateway-api`): all `/a2a/*` and `/mcp/*` routes require
-authentication when `ASYA_A2A_API_KEY` / `ASYA_MCP_API_KEY` are set.
+External traffic is exposed through the Ingress (`ingress.enabled=true`), not a
+per-Service LoadBalancer. The `asya-gateway-mesh-api-int` Service has no Ingress and
+is unreachable from outside the cluster.
 
-**Always public**: `/.well-known/agent.json` (A2A spec requirement) and `/health`
-(K8s probes).
-
-Clients must send the API key in the `X-API-Key` header for A2A, or
-`Authorization: Bearer <key>` for MCP:
+**A2A auth** is configured via `a2a.auth.apiKey` (→ `ASYA_A2A_API_KEY`) or
+`a2a.auth.jwt.*`. When set, clients must send the API key in the `X-API-Key` header.
+MCP auth is not currently wired in the mcp-adapter.
 
 ```bash
 A2A_KEY=$(kubectl get secret asya-gateway-auth -n $NS \
   -o jsonpath='{.data.a2a-api-key}' | base64 -d)
 
-curl -X POST http://${GATEWAY_IP}/a2a/hello \
+curl -X POST https://<your-gateway-host>/a2a/ \
   -H "X-API-Key: $A2A_KEY" \
   -H "Content-Type: application/json" \
   -d '...'
 ```
 
-**For production exposure** (beyond a local demo), configure HTTPS before sharing
-the gateway URL externally:
+**For production exposure** (beyond a local demo), terminate TLS at the Ingress
+before sharing the gateway URL externally:
 
-- **GCP-managed certificate**: annotate the Service or Ingress with
+- **GCP-managed certificate**: annotate the Ingress with
   `networking.gke.io/managed-certificates` pointing to a `ManagedCertificate` resource.
-  Requires a domain name with an A record pointing at the LoadBalancer IP.
+  Requires a domain name with an A record pointing at the Ingress IP.
 - **cert-manager + Ingress**: standard Kubernetes approach, works with Let's Encrypt.
-- The MCP OAuth 2.1 flow (already implemented in the gateway) formally requires HTTPS
-  — HTTP is acceptable for API key auth but not for OAuth redirect URIs.
 
 ---
 
@@ -597,31 +632,20 @@ Watch the actor become ready (Crossplane creates the Pub/Sub topic and subscript
 kubectl get asyncactor hello -n $NS -w
 ```
 
-Register the `hello` flow with the gateway. The gateway hot-reloads its
-`flows.yaml` ConfigMap — patching it is all that's needed:
+Register the `hello` flow with the gateway as an MCP tool and/or A2A agent. Tool and
+agent definitions are mounted as ConfigMaps into the mcp-adapter and a2a-adapter and
+hot-reloaded — see the [Gateway Setup Guide](guide-gateway.md) for how to compile and
+register flows.
+
+Send a test message via the gateway (replace `<your-gateway-host>` with the
+`ingress.host` you set above; for a quick local check, `kubectl port-forward
+svc/asya-gateway-a2a 8083:8083 -n $NS` and use `localhost:8083`):
 
 ```bash
-kubectl patch configmap asya-gateway-flows -n $NS --type merge -p '
-data:
-  flows.yaml: |
-    flows:
-    - name: hello
-      entrypoint: hello
-      description: A simple hello world actor
-      mcp:
-        progress: true
-'
-```
-
-Send a test message via the gateway:
-
-```bash
-GATEWAY_IP=$(kubectl -n $NS get svc asya-gateway-api \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 A2A_KEY=$(kubectl get secret asya-gateway-auth -n $NS \
   -o jsonpath='{.data.a2a-api-key}' | base64 -d)
 
-curl -s -X POST http://${GATEWAY_IP}/a2a/hello \
+curl -s -X POST https://<your-gateway-host>/a2a/ \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $A2A_KEY" \
   -d '{"jsonrpc":"2.0","id":"1","method":"message/send","params":{
@@ -642,35 +666,29 @@ kubectl get asyncactors -n $NS
 # Pub/Sub topics created by Crossplane
 gcloud pubsub topics list --project=$PROJECT | grep asya
 
-# Gateway IP and API keys
-GATEWAY_IP=$(kubectl -n $NS get svc asya-gateway-api \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+# Gateway host (the ingress.host you set) and A2A key.
+# External traffic is path-routed by the Ingress to the per-protocol services:
+#   /mcp -> asya-gateway-mcp, /a2a/ + /.well-known/agent.json -> asya-gateway-a2a
+GATEWAY_HOST=<your-gateway-host>
 A2A_KEY=$(kubectl get secret asya-gateway-auth -n $NS \
   -o jsonpath='{.data.a2a-api-key}' | base64 -d)
-MCP_KEY=$(kubectl get secret asya-gateway-auth -n $NS \
-  -o jsonpath='{.data.mcp-api-key}' | base64 -d)
-
-# Health (public, no key needed)
-curl http://${GATEWAY_IP}/health
 
 # A2A agent card (public, no key needed)
-curl http://${GATEWAY_IP}/.well-known/agent.json | python3 -m json.tool
+curl https://${GATEWAY_HOST}/.well-known/agent.json | python3 -m json.tool
 
-# MCP tools list (requires MCP key)
+# MCP tools list (MCP auth is not currently wired in the adapter)
 SESSION_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
-curl -s -X POST http://${GATEWAY_IP}/mcp \
+curl -s -X POST https://${GATEWAY_HOST}/mcp \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $MCP_KEY" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' > /dev/null
-curl -s -X POST http://${GATEWAY_IP}/mcp \
+curl -s -X POST https://${GATEWAY_HOST}/mcp \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $MCP_KEY" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | python3 -m json.tool
 
 # End-to-end test via A2A (requires A2A key)
-curl -s -X POST http://${GATEWAY_IP}/a2a/hello \
+curl -s -X POST https://${GATEWAY_HOST}/a2a/ \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $A2A_KEY" \
   -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"test-1","role":"user","parts":[{"kind":"text","text":"hello"}]}}}' \


### PR DESCRIPTION
## What

Reconciles the broader gateway-architecture documentation with the current
**split-gateway** reality. The gateway was rearchitected from a single binary
with `api`/`mesh` modes and mandatory PostgreSQL into split containers — all from
the one `asya-gateway` image, selected via `command:`:

- `mesh-api` (default entrypoint, ports 8080 external / 8081 internal)
- `mcp-adapter` (`./mcp-adapter`, :8082)
- `a2a-adapter` (`./a2a-adapter`, :8083)
- `state-proxy-mesh` sidecar for task/mesh state

State is pluggable via `stateProxy.mesh.backend`: `pg-kv` (PostgreSQL, default) or
`pvc-kv` (DuckDB-over-JSON on a PVC / in-memory) — **PostgreSQL is no longer
mandatory**. `ASYA_GATEWAY_MODE` and the old `asya-gateway-api` / `asya-gateway-mesh`
mode-based deployments/services are gone; services are now `asya-gateway-mesh-api`
(8080), `-mesh-api-int` (8081), `-mcp` (8082), `-a2a` (8083).

## Independent of #507

This PR is **independent of #507** (flow-registration mechanism). It does **not**
touch `docs/setup/guide-gateway.md` or `docs/usage/guide-agentic-patterns.md` —
those are owned by #507. Where these docs reference flow registration, they
cross-link to `guide-gateway.md` rather than re-documenting it.

## Files updated

- `docs/reference/components/core-gateway.md` — biggest edit: api/mesh modes →
  split containers; PostgreSQL → `pg-kv` OR `pvc-kv`; corrected service
  names/ports, endpoints (`/api/v1/mesh/...`), state-ownership diagram, and
  auth (A2A only; MCP auth / OAuth 2.1 / `/tools/call` removed in code).
- `docs/reference/env-vars.md` — replaced the stale single-binary `asya-gateway`
  section (removed `ASYA_GATEWAY_MODE`, `ASYA_DATABASE_URL`, `ASYA_GATEWAY_PORT`,
  `ASYA_CONFIG_*`, DB-pool vars, MCP OAuth vars) with a pointer to the per-binary
  sections; added `ASYA_BACKSTOP_INTERVAL` and a `pvc-kv` state-proxy section.
- `docs/concepts/http-gateway.md` — two deployment modes → split containers;
  pluggable state backend.
- `docs/reference/credentials.md` — gateway DB secret model corrected (pg-kv reads
  `DB_PASSWORD` via `database.existingSecret`; no DSN secret / init container;
  pvc-kv needs none); `a2a.auth.apiKey`.
- `docs/setup/guide-pause-resume.md` — task-status URL → `asya-gateway-mesh-api`
  service + `/api/v1/mesh/<id>` path.
- `docs/setup/start-gcp-gke.md` — split-gateway install with `pvc-kv` (no-Postgres)
  and `pg-kv` options, `database.*` values, Ingress instead of LoadBalancer,
  `asya-gateway-mcp` / `-a2a` services, dropped OAuth claim, `/a2a/hello` → `/a2a/`,
  removed stale `sidecar.gatewayURL` flag.

## Key corrections

- api/mesh modes → split containers (one image, `command:`-selected)
- PostgreSQL now optional via `pvc-kv`
- service-name / port updates (`asya-gateway-mesh-api[-int]`, `-mcp`, `-a2a`)
- removed-in-code endpoints/auth dropped: OAuth 2.1, `/tools/call`,
  `/mesh/config-reload`, MCP auth wiring

## Verification

- All env vars, endpoints, service names, and Helm values verified against the
  current chart (`deploy/helm-charts/asya-gateway/`), the e2e profiles
  (`sqs-s3-pvc.yaml`, `pubsub-gcs-pg.yaml`), and the gateway source
  (`src/asya-gateway/cmd/{mesh-api,mcp-adapter,a2a-adapter}`).
- All internal doc links resolve; pre-commit hooks pass.

## Intentionally left stale (out of scope)

- `docs/reference/specs/gateway-api.md` — still lists `/tools/call`, `/oauth/*`,
  `/mesh/config-reload`, `/stream/{id}`, "two deployments". It did **not** match
  the staleness grep and is a large spec deserving its own follow-up.
- `src/asya-gateway/README.md` — source README (not under `docs/`), still
  describes the single binary.